### PR TITLE
Use native namespace setting

### DIFF
--- a/connect/README.md
+++ b/connect/README.md
@@ -63,7 +63,6 @@ $ helm install --set connect.applicationName=connect connect ./connect
 | connect.sync.name | string | `"connect-sync"` | The name of the 1Password Connect Sync container |
 | connect.sync.resources | object | `{}` | The resources requests/limits for the 1Password Connect Sync pod |
 | connect.version | string | `"0.3"` | The 1Password Connect version to pull |
-| namespace | string | `"default"` | The namespace in which to deploy 1Password Connect |
 | operator.autoRestart | boolean | `false` | Denotes whether the 1Password Connect Operator will automatically restart deployments based on associated updated secrets. |
 | operator.create | boolean | `false` | Denotes whether the 1Password Connect Operator will be deployed |
 | operator.imagePullPolicy | string | `"IfNotPresent` | The 1Password Connect Operator image pull policy |

--- a/connect/README.md
+++ b/connect/README.md
@@ -79,4 +79,4 @@ $ helm install --set connect.applicationName=connect connect ./connect
 | operator.token.key | string | `"token"` | The key for the 1Password Connect token stored in the 1Password token secret |
 | operator.token.name | string | `"onepassword-token"` | The name of Kubernetes Secret containing the 1Password Connect API token |
 | operator.token.value | string | `"onepassword-token"` | An API token generated for 1Password Connect to be used by the Connect Operator |
-| operator.watchNamespace | {} | `"-default"` | A list of Namespaces for the 1Password Connect Operator to watch and manage |
+| operator.watchNamespace | {} | .Release.Namespace | A list of Namespaces for the 1Password Connect Operator to watch and manage |

--- a/connect/templates/NOTES.txt
+++ b/connect/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{- $credentialsName := .Values.connect.credentialsName -}}
-{{- $namespace := .Values.namespace -}}
+{{- $namespace := .Release.Namespace -}}
 {{- $tokenName := .Values.operator.token.name -}}
 
 {{- if not ( or (lookup "v1" "Secret" ( $namespace ) ( $credentialsName )) (.Values.connect.credentials)) }}

--- a/connect/templates/connect-credentials.yaml
+++ b/connect/templates/connect-credentials.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.connect.credentialsName }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:
   {{ .Values.connect.credentialsKey }}: |-

--- a/connect/templates/connect-deployment.yaml
+++ b/connect/templates/connect-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.connect.applicationName }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/connect/templates/operator-deployment.yaml
+++ b/connect/templates/operator-deployment.yaml
@@ -22,7 +22,7 @@ spec:
           command: ["/manager"]
           env:
             - name: WATCH_NAMESPACE
-              value: {{ include "helm-toolkit.utils.joinListWithComma" .Values.operator.watchNamespace }}
+              value: {{ include "helm-toolkit.utils.joinListWithComma" .Values.operator.watchNamespace | default .Release.Namespace }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/connect/templates/operator-deployment.yaml
+++ b/connect/templates/operator-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.operator.applicationName }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:

--- a/connect/templates/operator-token.yaml
+++ b/connect/templates/operator-token.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.operator.token.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:
   {{ .Values.operator.token.key }}: {{ .Values.operator.token.value }}

--- a/connect/templates/service.yaml
+++ b/connect/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.connect.applicationName }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   type: NodePort
   selector:

--- a/connect/values.yaml
+++ b/connect/values.yaml
@@ -26,8 +26,8 @@ operator:
   imageRepository: 1password/onepassword-operator
   pollingInterval: 10
   version: "1.0.0"
-  watchNamespace:
-   - "default"
+  watchNamespace: 
+    - ""
   token:
     name: onepassword-token
     key: token

--- a/connect/values.yaml
+++ b/connect/values.yaml
@@ -18,8 +18,6 @@ connect:
   imagePullPolicy: IfNotPresent
   version: "1.0.0"
 
-namespace: default 
-
 operator:
   create: false
   autoRestart: false


### PR DESCRIPTION
Helm already has a way to set the target namespace, which we were ignoring. 

This PR uses `.Release.Namespace` as the target namespace now, so you can run `helm install` with `--namespace my-namespace` instead of `--set namespace=my-namespace`.

Also, the `WATCH_NAMESPACE` var will default to `.Release.Namespace`.