### PR TITLE
Remove fixed specification of NodePort

### DIFF
--- a/connect/templates/service.yaml
+++ b/connect/templates/service.yaml
@@ -10,7 +10,5 @@ spec:
   ports:
     - port: 8080
       name: {{ .Values.connect.api.name }}
-      nodePort: 31080
     - port: 8081
       name: {{ .Values.connect.sync.name }}
-      nodePort: 31081


### PR DESCRIPTION
This will let Kubernetes find a free port, resolving issues with the port already being acquired by another service.

This should also resolve #22.