### PR TITLE
Define default Security Contexts for containers

### DIFF
--- a/connect/templates/connect-deployment.yaml
+++ b/connect/templates/connect-deployment.yaml
@@ -40,6 +40,14 @@ spec:
         - name: {{ .Values.connect.api.name }}
           image: {{ .Values.connect.api.imageRepository }}:{{ .Values.connect.version | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.connect.imagePullPolicy }}
+          securityContext:
+            runAsUser: 999
+            runAsGroup: 999
+            allowPrivilegeEscalation: false
+            capabilities:
+              add:
+              - "NET_ADMIN"
+              - "NET_BROADCAST"
           resources:
             {{- toYaml .Values.connect.sync.resources | nindent 12 }}
           ports:
@@ -56,6 +64,14 @@ spec:
         - name: connect-sync
           image: {{ .Values.connect.sync.imageRepository }}:{{ .Values.connect.version | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.connect.imagePullPolicy }}
+          securityContext:
+            runAsUser: 999
+            runAsGroup: 999
+            allowPrivilegeEscalation: false
+            capabilities:
+              add:
+              - "NET_ADMIN"
+              - "NET_BROADCAST"
           resources:
             {{- toYaml .Values.connect.sync.resources | nindent 12 }}
           ports:

--- a/connect/templates/connect-deployment.yaml
+++ b/connect/templates/connect-deployment.yaml
@@ -45,8 +45,9 @@ spec:
             runAsGroup: 999
             allowPrivilegeEscalation: false
             capabilities:
+              drop:
+              - all
               add:
-              - "NET_ADMIN"
               - "NET_BROADCAST"
           resources:
             {{- toYaml .Values.connect.sync.resources | nindent 12 }}
@@ -69,8 +70,10 @@ spec:
             runAsGroup: 999
             allowPrivilegeEscalation: false
             capabilities:
+            capabilities:
+              drop:
+              - all
               add:
-              - "NET_ADMIN"
               - "NET_BROADCAST"
           resources:
             {{- toYaml .Values.connect.sync.resources | nindent 12 }}

--- a/connect/templates/operator-deployment.yaml
+++ b/connect/templates/operator-deployment.yaml
@@ -25,6 +25,12 @@ spec:
         - name: {{ .Values.connect.applicationName }}
           image: {{ .Values.operator.imageRepository }}:{{ .Values.operator.version | default "latest" }}
           imagePullPolicy: {{ .Values.connect.imagePullPolicy }}
+          securityContext:
+            runAsUser: 65532
+            runAsGroup: 65532
+            allowPrivilegeEscalation: false
+            capabilities:
+              add: []
           command: ["/manager"]
           env:
             - name: WATCH_NAMESPACE

--- a/connect/templates/operator-deployment.yaml
+++ b/connect/templates/operator-deployment.yaml
@@ -30,7 +30,8 @@ spec:
             runAsGroup: 65532
             allowPrivilegeEscalation: false
             capabilities:
-              add: []
+              drop:
+                - all
           command: ["/manager"]
           env:
             - name: WATCH_NAMESPACE

--- a/connect/templates/rolebinding.yaml
+++ b/connect/templates/rolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
   name: {{ $name }}-{{ $namespace }}
   namespace: {{ $namespace }}
   labels:
-    {{- include "onepassword-connect.labels" . | nindent 4 }}
+    {{- include "onepassword-connect.labels" $ | nindent 4 }}
 subjects:
 - kind: ServiceAccount
   name: {{ $serviceAccountName }}

--- a/connect/values.yaml
+++ b/connect/values.yaml
@@ -10,7 +10,7 @@ connect:
     resources: {}
   credentialsName: op-credentials
   credentialsKey: 1password-credentials.json
-  credentials: 
+  credentials:
   dataVolume:
     name: shared-data
     type: emptyDir
@@ -28,12 +28,11 @@ operator:
   pollingInterval: 10
   version: "1.0.0"
   nodeSelector: {}
-  watchNamespace: 
-    - ""
+  watchNamespace: []
   token:
     name: onepassword-token
     key: token
-    value: 
+    value:
 
   serviceAccount:
     create: false


### PR DESCRIPTION
Add security context to Connect and Operator containers 
Resolves #12 

- Connect api and sync default to user 999
- Operator defaults to 65532 according to [base image documentation](https://github.com/GoogleContainerTools/distroless/blob/2e539660094d9c2910f6134df1d0d3919479c393/base/base.bzl#L9)
- Neither container is allowed to escalate permissions
- Add multicast capabilities to the `connect-api` and `connect-sync` containers

Also resolve templating issue with Role Binding

- Inside of range the context needs to be $
- The default value for `watchNamespace` should be an empty list rather than empty string namespace