### PR TITLE
Set correct remote branch in release script

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -75,7 +75,7 @@ function _main() {
     # Stash version changes
     git stash push &>/dev/null
 
-    if ! git checkout -b "${RELEASE_BRANCH}" origin/"${MAIN_BRANCH:-main}"; then
+    if ! git checkout -b "${RELEASE_BRANCH}" origin/"${RELEASE_BRANCH}"; then
         echo "[ERROR] Could not check out release branch." >&2
         git stash pop &>/dev/null
         exit 1


### PR DESCRIPTION
We do not want the release branch to track remote main... It should track the release branch.