### PR TITLE
Create Actions workflows for CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint charts
 on: [push, pull_request]
 
 jobs:
-  lint-test:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: Lint charts
+on: [push, pull_request]
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.1
+
+      # Set up Python for ct lint, which needs Python for Yamale and yamllint
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up ct CLI
+        uses: helm/chart-testing-action@v2.0.1
+        with:
+          version: v3.3.0
+
+      - name: Lint chart
+        run: ct lint --config ct.yaml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: Run acceptance tests
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.1
+
+      - name: Set up ct CLI
+        uses: helm/chart-testing-action@v2.0.1
+        with:
+          version: v3.3.0
+
+      - name: Check if chart has changed
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config ct.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Install yq
+        run: sudo snap install yq
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Add secrets to YAML test cases
+        env:
+          OP_CONNECT_CREDENTIALS: ${{ secrets.OP_CONNECT_CREDENTIALS }}
+          OP_CONNECT_TOKEN: ${{ secrets.OP_CONNECT_TOKEN }}
+        run: |
+          ls -d connect/ci/*.yaml | xargs -I '{}' yq eval '.connect.credentials = strenv(OP_CONNECT_CREDENTIALS) | .operator.token.value = strenv(OP_CONNECT_TOKEN)' -i {}
+
+      - name: Spin up local Kubernetes cluster
+        uses: helm/kind-action@v1.1.0
+
+      - name: Deploy and run acceptance tests
+        run: ct install --config ct.yaml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,12 +32,27 @@ jobs:
         run: sudo snap install yq
         if: steps.list-changed.outputs.changed == 'true'
 
-      - name: Add secrets to YAML test cases
+      - name: Add fixtures to YAML test cases
         env:
           OP_CONNECT_CREDENTIALS: ${{ secrets.OP_CONNECT_CREDENTIALS }}
           OP_CONNECT_TOKEN: ${{ secrets.OP_CONNECT_TOKEN }}
         run: |
-          ls -d connect/ci/*.yaml | xargs -I '{}' yq eval '.connect.credentials = strenv(OP_CONNECT_CREDENTIALS) | .operator.token.value = strenv(OP_CONNECT_TOKEN)' -i {}
+          cat > fixtures.yaml << EOF
+          acceptanceTests:
+            enabled: true
+            fixtures:
+              vaultId: dgo4fcbuv3gh2gw6xvdhjvqp6a
+              itemId: ultuydxz3us3mt2trin4bikrvu
+              secretValue: RGVhciBzZWN1cml0eSByZXNlYXJjaGVyLCB0aGlzIGlzIGp1c3QgYSBkdW1teSBzZWNyZXQuIFBsZWFzZSBkb24ndCByZXBvcnQgaXQu
+          EOF
+
+          for values_file in connect/ci/*.yaml; do
+            # Add secrets
+            yq eval '.connect.credentials = strenv(OP_CONNECT_CREDENTIALS) | .operator.token.value = strenv(OP_CONNECT_TOKEN)' -i $values_file
+
+            # Add acceptance test fixtures
+            yq eval-all --inplace 'select(fileIndex == 0) * select(fileIndex == 1)' $values_file fixtures.yaml
+          done
 
       - name: Spin up local Kubernetes cluster
         uses: helm/kind-action@v1.1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Run acceptance tests
-on: [push, pull_request]
+on: [push]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,8 @@ jobs:
           acceptanceTests:
             enabled: true
             fixtures:
-              vaultId: dgo4fcbuv3gh2gw6xvdhjvqp6a
-              itemId: ultuydxz3us3mt2trin4bikrvu
+              vaultId: v5pz6venw4roosmkzdq2nhpv6u
+              itemId: hrgkzhrlvscomepxlgafb2m3ca
               secretValue: RGVhciBzZWN1cml0eSByZXNlYXJjaGVyLCB0aGlzIGlzIGp1c3QgYSBkdW1teSBzZWNyZXQuIFBsZWFzZSBkb24ndCByZXBvcnQgaXQu
           EOF
 

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,4 +1,3 @@
-
 repositoryID: ee358a06-61d2-4dab-93f6-cf46c40c1420
 owners: 
   - name: 1Password

--- a/connect/Chart.yaml
+++ b/connect/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - "1Password Connect"
   - "1Password Operator"
 home: https://1password.com/secrets/
-maintainers: # (optional)
+maintainers:
   - name: 1Password Secrets Integrations Team
     email: support+business@1password.com
 icon: https://1password.com/img/logo-v1.svg

--- a/connect/ci/with-operator-values.yaml
+++ b/connect/ci/with-operator-values.yaml
@@ -1,0 +1,10 @@
+operator:
+  create: true
+  serviceAccount:
+    create: true
+  roleBinding:
+    create: true
+  clusterRole:
+    create: true
+  token:
+    name: op-operator-connect-token

--- a/connect/templates/tests/health-check.yml
+++ b/connect/templates/tests/health-check.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-health-check"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "onepassword-connect.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-weight: "1"
+spec:
+  restartPolicy: Never
+  containers:
+    - name: curl
+      image: curlimages/curl
+      command: ["curl", "http://{{ .Values.connect.applicationName }}:8080/health"]

--- a/connect/templates/tests/secret-read.yml
+++ b/connect/templates/tests/secret-read.yml
@@ -1,4 +1,4 @@
-{{- $secretValue := "RGVhciBzZWN1cml0eSByZXNlYXJjaGVyLCB0aGlzIGlzIGp1c3QgYSBkdW1teSBzZWNyZXQuIFBsZWFzZSBkb24ndCByZXBvcnQgaXQu" -}}
+{{- if and .Values.acceptanceTests.enabled .Values.operator.create -}}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -17,7 +17,7 @@ spec:
       command: ["sh", "-c"]
       args:
         - |
-          if [ "$SECRET" != "{{ $secretValue }}" ]; then
+          if [ "$SECRET" != "{{ .Values.acceptanceTests.fixtures.secretValue }}" ]; then
             echo "⛔️ Secret is not set as expected"
             exit 1;
           fi
@@ -30,3 +30,4 @@ spec:
             secretKeyRef:
               name: "{{ .Release.Name }}-test-secret"
               key: password
+{{- end }}

--- a/connect/templates/tests/secret-read.yml
+++ b/connect/templates/tests/secret-read.yml
@@ -1,0 +1,32 @@
+{{- $secretValue := "RGVhciBzZWN1cml0eSByZXNlYXJjaGVyLCB0aGlzIGlzIGp1c3QgYSBkdW1teSBzZWNyZXQuIFBsZWFzZSBkb24ndCByZXBvcnQgaXQu" -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-secret-read"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "onepassword-connect.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-weight: "3"
+spec:
+  restartPolicy: Never
+  containers:
+    - name: secret-assertion
+      image: alpine
+      command: ["sh", "-c"]
+      args:
+        - |
+          if [ "$SECRET" != "{{ $secretValue }}" ]; then
+            echo "⛔️ Secret is not set as expected"
+            exit 1;
+          fi
+
+          echo "🎉 Successfully read secret from 1Password:"
+          echo $SECRET
+      env:
+        - name: SECRET
+          valueFrom:
+            secretKeyRef:
+              name: "{{ .Release.Name }}-test-secret"
+              key: password

--- a/connect/templates/tests/setup-secret-read.yml
+++ b/connect/templates/tests/setup-secret-read.yml
@@ -1,0 +1,15 @@
+{{- $vaultID := "dgo4fcbuv3gh2gw6xvdhjvqp6a" -}}
+{{- $itemID := "ultuydxz3us3mt2trin4bikrvu" -}}
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: "{{ .Release.Name }}-test-secret"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "onepassword-connect.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-weight: "2"
+spec:
+  itemPath: "vaults/{{ $vaultID }}/items/{{ $itemID }}"

--- a/connect/templates/tests/setup-secret-read.yml
+++ b/connect/templates/tests/setup-secret-read.yml
@@ -1,6 +1,4 @@
-{{- $vaultID := "dgo4fcbuv3gh2gw6xvdhjvqp6a" -}}
-{{- $itemID := "ultuydxz3us3mt2trin4bikrvu" -}}
----
+{{- if and .Values.acceptanceTests.enabled .Values.operator.create -}}
 apiVersion: onepassword.com/v1
 kind: OnePasswordItem
 metadata:
@@ -12,4 +10,5 @@ metadata:
     helm.sh/hook: test
     helm.sh/hook-weight: "2"
 spec:
-  itemPath: "vaults/{{ $vaultID }}/items/{{ $itemID }}"
+  itemPath: "vaults/{{ .Values.acceptanceTests.fixtures.vaultId }}/items/{{ .Values.acceptanceTests.fixtures.itemId }}"
+{{- end }}

--- a/connect/values.yaml
+++ b/connect/values.yaml
@@ -50,4 +50,3 @@ operator:
 service:
   type: Nodeport
   port: 8080
-

--- a/connect/values.yaml
+++ b/connect/values.yaml
@@ -29,7 +29,7 @@ operator:
   version: "1.0.0"
   nodeSelector: {}
   watchNamespace:
-    - "{{ .Release.Namespace }}" # This will be interpolated in the templates, using the tpl function
+    - "{{ .Release.Namespace }}"  # This will be interpolated in the templates, using the tpl function
   token:
     name: onepassword-token
     key: token

--- a/connect/values.yaml
+++ b/connect/values.yaml
@@ -51,3 +51,7 @@ operator:
 service:
   type: Nodeport
   port: 8080
+
+acceptanceTests:
+  enabled: false
+  fixtures: {}

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,6 +1,8 @@
 remote: origin
 target-branch: main
 validate-maintainers: false
+debug: true
+helm-extra-args: --timeout 120s
 chart-dirs: ["."]
 charts:
   - connect

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,6 @@
+remote: origin
+target-branch: main
+validate-maintainers: false
+chart-dirs: ["."]
+charts:
+  - connect


### PR DESCRIPTION
This PR adds GitHub Actions workflows for linting and testing the Helm chart.

For the test, it will check if the chart has changed compared to the upstream, and if so, it spins up a local Kubernetes cluster and deploys Connect and the operator.

Then it deploys another pod onto the cluster that performs a health check of the Connect instance.
And to finish it off, it deploys a OnePasswordItem CRD that references a test secret and it deploys another pod onto the cluster that tries to load that test secret as a Kubernetes Secret.

#### TODO
- [x] Lint workflow
- [x] Test workflow
- [x] Use shared vault in acceptance tests