### PR TITLE
Watch .Release.Namespace by default

### DIFF
--- a/connect/README.md
+++ b/connect/README.md
@@ -81,4 +81,4 @@ $ helm install --set connect.applicationName=connect connect ./connect
 | operator.token.key | string | `"token"` | The key for the 1Password Connect token stored in the 1Password token secret |
 | operator.token.name | string | `"onepassword-token"` | The name of Kubernetes Secret containing the 1Password Connect API token |
 | operator.token.value | string | `"onepassword-token"` | An API token generated for 1Password Connect to be used by the Connect Operator |
-| operator.watchNamespace | {} | .Release.Namespace | A list of Namespaces for the 1Password Connect Operator to watch and manage |
+| operator.watchNamespace | {} | [`{{ .Release.Namespace }}`] | A list of Namespaces for the 1Password Connect Operator to watch and manage |

--- a/connect/templates/operator-deployment.yaml
+++ b/connect/templates/operator-deployment.yaml
@@ -35,7 +35,7 @@ spec:
           command: ["/manager"]
           env:
             - name: WATCH_NAMESPACE
-              value: {{ include "helm-toolkit.utils.joinListWithComma" .Values.operator.watchNamespace | default .Release.Namespace }}
+              value: {{ tpl (include "helm-toolkit.utils.joinListWithComma" .Values.operator.watchNamespace) . }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/connect/templates/rolebinding.yaml
+++ b/connect/templates/rolebinding.yaml
@@ -3,6 +3,7 @@
 {{- $clusterRoleName := .Values.operator.clusterRole.name -}}
 {{- $serviceAccountName := .Values.operator.serviceAccount.name -}}
 {{- range $namespace := .Values.operator.watchNamespace }}
+{{- $namespace = tpl $namespace $ -}}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/connect/values.yaml
+++ b/connect/values.yaml
@@ -28,7 +28,7 @@ operator:
   pollingInterval: 10
   version: "1.0.0"
   nodeSelector: {}
-  watchNamespace: []
+  watchNamespace: ["{{ .Release.Namespace }}"] # This will be interpolated in the templates, using the tpl function
   token:
     name: onepassword-token
     key: token

--- a/connect/values.yaml
+++ b/connect/values.yaml
@@ -28,7 +28,8 @@ operator:
   pollingInterval: 10
   version: "1.0.0"
   nodeSelector: {}
-  watchNamespace: ["{{ .Release.Namespace }}"] # This will be interpolated in the templates, using the tpl function
+  watchNamespace:
+    - "{{ .Release.Namespace }}" # This will be interpolated in the templates, using the tpl function
   token:
     name: onepassword-token
     key: token
@@ -50,4 +51,3 @@ operator:
 service:
   type: Nodeport
   port: 8080
-


### PR DESCRIPTION
When setting `--namespace`, you'd expect that by default the specified namespace would be watched by the operator.

This was addressed already in https://github.com/1Password/connect-helm-charts/pull/18, but was [reverted](https://github.com/1Password/connect-helm-charts/pull/25/commits/3cae01c755d141cd46bff849c8302fe22a57f12b) due to breaking the cluster role bindings. This PR resolves that.

Small note on the implementation: `values.yaml` doesn't support interpolation directly. So as a workaround, we have to interpolate `.Release.Namespace` on the template side using the `tpl` function.
