### PR TITLE
Move CRD out of templates into crds dir

### DIFF
--- a/connect/README.md
+++ b/connect/README.md
@@ -82,3 +82,8 @@ $ helm install --set connect.applicationName=connect connect ./connect
 | operator.token.name | string | `"onepassword-token"` | The name of Kubernetes Secret containing the 1Password Connect API token |
 | operator.token.value | string | `"onepassword-token"` | An API token generated for 1Password Connect to be used by the Connect Operator |
 | operator.watchNamespace | {} | [`{{ .Release.Namespace }}`] | A list of Namespaces for the 1Password Connect Operator to watch and manage |
+
+### CRD
+
+By default, the chart will also install the `OnePasswordItem` CRD.
+To disable this, you can run `helm install` with the [`--skip-crds` flag](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#method-1-let-helm-do-it-for-you).

--- a/connect/crds/onepassworditem-crd.yaml
+++ b/connect/crds/onepassworditem-crd.yaml
@@ -1,10 +1,9 @@
-{{- if .Values.operator.create -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: onepassworditems.onepassword.com
   labels:
-    {{- include "onepassword-connect.labels" . | nindent 4 }}
+    app.kubernetes.io/name: onepassword-connect
 spec:
   group: onepassword.com
   names:
@@ -43,4 +42,3 @@ spec:
             description: OnePasswordItemStatus defines the observed state of OnePasswordItem
             type: object
         type: object
-{{- end }}


### PR DESCRIPTION
As per the [Helm 3 recommendations](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/) the CRD is now removed from the `templates` dir to the `crds` dir. This does mean that we lose the ability to template.

So previously, the way to skip the CRD would be `--set operator.create=false`, but now you'd have to set `--skip-crds`.