### PR TITLE
Create RBAC resources by default when operator is enabled

### DIFF
--- a/connect/README.md
+++ b/connect/README.md
@@ -14,7 +14,7 @@ In order to deploy the 1Password Connect Kubernetes Operator along side 1Passwor
 
 Please note the following:
 
-1. This operator expects that a secret containing an API token for 1Password Connect is saved to the configured namespace.
+This operator expects that a secret containing an API token for 1Password Connect is saved to the configured namespace.
 Creation of a secret for the token can be automated by the Helm Chart by using `--set operator.token.value=<token>`.
 
 If you would prefer to create the token secret manually, the token can be saved as a Kubernetes secret using the following command:
@@ -24,8 +24,6 @@ $ kubectl create secret generic <token-name> --from-literal=token=<OP_CONNECT_TO
 ```
 
 More information about 1Password Connect and how to generate a 1Password Connect API token can be found at https://support.1password.com/cs/connect/.
-
-2. The Operator also requires setting permissions in Kubernetes in order to allow it to run. By setting `operator.serviceAccount.create`, `operator.roleBinding.create`, and `operator.clusterRole.create` to true, the Helm chart will take care of setting a basic service account, role binding, and cluster role for the opreator. Although this process can be automated please ensure you give the Operator the appropriate permissions for your environment.
 
 ## Configuration Values
 The 1Password Connect Helm chart offers many configuration options for deployment. Please refer to the list below for information on what configuration options are available as well as what the default configuration options are.
@@ -70,12 +68,12 @@ $ helm install --set connect.applicationName=connect connect ./connect
 | operator.imageRepository | string | `"1password/onepassword-operator` | The 1Password Connect Operator repository |
 | operator.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) stanza for the operator pod |
 | operator.pollingInterval | integer | `600` | How often the 1Password Connect Operator will poll for secrets updates. |
-| operator.clusterRole.create | boolean | `false` | Denotes whether or not a cluster role will be created for each for the 1Password Connect Operator |
+| operator.clusterRole.create | boolean | `{{ .Values.operator.create }}` | Denotes whether or not a cluster role will be created for each for the 1Password Connect Operator |
 | operator.clusterRole.name | string | `"onepassword-connect-operator"` | The name of the 1Password Connect Operator Cluster Role |
-| operator.roleBinding.create | boolean | `false` | Denotes whether or not a role binding will be created for each Namespace for the 1Password Connect Operator Service Account |
+| operator.roleBinding.create | boolean | `{{ .Values.operator.create }}` | Denotes whether or not a role binding will be created for each Namespace for the 1Password Connect Operator Service Account |
 | operator.roleBinding.name | string | `"onepassword-connect-operator"` | The name of the 1Password Connect Operator Role Binding |
 | operator.serviceAccount.annotations | object | `{}` | Annotations for the 1Password Connect Service Account |
-| operator.serviceAccount.create | boolean | `false` | Denotes whether or not a service account will be created for the 1Password Connect Operator |
+| operator.serviceAccount.create | boolean | `{{ .Values.operator.create }}` | Denotes whether or not a service account will be created for the 1Password Connect Operator |
 | operator.serviceAccount.name | string | `"onepassword-connect-operator"` | The name of the 1Password Conenct Operator |
 | operator.version | string | `"1.0.0"` | T 1Password Connect Operator version to pull |
 | operator.token.key | string | `"token"` | The key for the 1Password Connect token stored in the 1Password token secret |

--- a/connect/ci/with-operator-values.yaml
+++ b/connect/ci/with-operator-values.yaml
@@ -1,10 +1,4 @@
 operator:
   create: true
-  serviceAccount:
-    create: true
-  roleBinding:
-    create: true
-  clusterRole:
-    create: true
   token:
     name: op-operator-connect-token

--- a/connect/templates/clusterrole.yaml
+++ b/connect/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if eq (tpl (.Values.operator.clusterRole.create | toString) .) "true" -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -81,3 +82,4 @@ rules:
   - patch
   - update
   - watch
+{{- end }}

--- a/connect/templates/rolebinding.yaml
+++ b/connect/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.operator.roleBinding.create -}}
+{{- if eq (tpl (.Values.operator.roleBinding.create | toString) .) "true" -}}
 {{- $name := .Values.operator.roleBinding.name -}}
 {{- $clusterRoleName := .Values.operator.clusterRole.name -}}
 {{- $serviceAccountName := .Values.operator.serviceAccount.name -}}

--- a/connect/templates/serviceaccount.yaml
+++ b/connect/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.operator.serviceAccount.create -}}
+{{- if eq (tpl (.Values.operator.serviceAccount.create | toString) .) "true" -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/connect/values.yaml
+++ b/connect/values.yaml
@@ -36,16 +36,16 @@ operator:
     value:
 
   serviceAccount:
-    create: false
+    create: "{{ .Values.operator.create }}"  # This will be interpolated in the templates, using the tpl function
     annotations: {}
     name: onepassword-connect-operator
 
   roleBinding:
-    create: false
+    create: "{{ .Values.operator.create }}"  # This will be interpolated in the templates, using the tpl function
     name: onepassword-connect-operator
 
   clusterRole:
-    create: false
+    create: "{{ .Values.operator.create }}"  # This will be interpolated in the templates, using the tpl function
     name: onepassword-connect-operator
 
 service:


### PR DESCRIPTION
Previously, to get an out-of-the-box working operator, you'd have to add 4 flags: `--set operator.create=true --set operator.clusterRole.create=true --set operator.serviceAccount.create=true --set operator.roleBinding.create=true`.

This PR changes this behavior by taking whatever value the `operator.create` flag has as the default value of the RBAC resource creation flags.

So now, you only have to add `--set operator.create=true` and you get the correct RBAC setup. The resources can still individually be disabled by explicitly setting them to `false`.