### PR TITLE
Improve readability of values table in README

### DIFF
--- a/connect/README.md
+++ b/connect/README.md
@@ -50,7 +50,7 @@ $ helm install --set connect.applicationName=connect connect ./connect
 | connect.api.imageRepository | string | `"1password/connect-api` | The 1Password Connect API repository |
 | connect.api.name | string | `"connect-api"` | The name of the 1Password Connect API container |
 | connect.api.resources | object | `{}` | The resources requests/limits for the 1Password Connect API pod |
-| connect.credentials | jsonString |  | Contents of the 1password-credentials.json file for Connect. Can be set be adding `--set-file connect.credentials={path/to/1password-credentials.json}` to your helm install command |
+| connect.credentials | jsonString |  | Contents of the 1password-credentials.json file for Connect. Can be set be adding `--set-file connect.credentials=<path/to/1password-credentials.json>` to your helm install command |
 | connect.credentialsKey | string | `"op-session"` | The key for the 1Password Connect Credentials stored in the credentials secret |
 | connect.credentialsName | string | `"op-credentials"` | The name of Kubernetes Secret containing the 1Password Connect credentials |
 | connect.dataVolume.name | string | `"shared-data"` | The name of the shared volume used between 1Password Connect Containers |
@@ -61,25 +61,25 @@ $ helm install --set connect.applicationName=connect connect ./connect
 | connect.sync.imageRepository | string | `"1password/connect-sync` | The 1Password Connect Sync repository |
 | connect.sync.name | string | `"connect-sync"` | The name of the 1Password Connect Sync container |
 | connect.sync.resources | object | `{}` | The resources requests/limits for the 1Password Connect Sync pod |
-| connect.version | string | `{{ .Chart.AppVersion }}` | The 1Password Connect version to pull |
+| connect.version | string | `{{.Chart.AppVersion}}` | The 1Password Connect version to pull |
 | operator.autoRestart | boolean | `false` | Denotes whether the 1Password Connect Operator will automatically restart deployments based on associated updated secrets. |
 | operator.create | boolean | `false` | Denotes whether the 1Password Connect Operator will be deployed |
 | operator.imagePullPolicy | string | `"IfNotPresent` | The 1Password Connect Operator image pull policy |
 | operator.imageRepository | string | `"1password/onepassword-operator` | The 1Password Connect Operator repository |
 | operator.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) stanza for the operator pod |
 | operator.pollingInterval | integer | `600` | How often the 1Password Connect Operator will poll for secrets updates. |
-| operator.clusterRole.create | boolean | `{{ .Values.operator.create }}` | Denotes whether or not a cluster role will be created for each for the 1Password Connect Operator |
+| operator.clusterRole.create | boolean | `{{.Values.operator.create}}` | Denotes whether or not a cluster role will be created for each for the 1Password Connect Operator |
 | operator.clusterRole.name | string | `"onepassword-connect-operator"` | The name of the 1Password Connect Operator Cluster Role |
-| operator.roleBinding.create | boolean | `{{ .Values.operator.create }}` | Denotes whether or not a role binding will be created for each Namespace for the 1Password Connect Operator Service Account |
+| operator.roleBinding.create | boolean | `{{.Values.operator.create}}` | Denotes whether or not a role binding will be created for each Namespace for the 1Password Connect Operator Service Account |
 | operator.roleBinding.name | string | `"onepassword-connect-operator"` | The name of the 1Password Connect Operator Role Binding |
 | operator.serviceAccount.annotations | object | `{}` | Annotations for the 1Password Connect Service Account |
-| operator.serviceAccount.create | boolean | `{{ .Values.operator.create }}` | Denotes whether or not a service account will be created for the 1Password Connect Operator |
+| operator.serviceAccount.create | boolean | `{{.Values.operator.create}}` | Denotes whether or not a service account will be created for the 1Password Connect Operator |
 | operator.serviceAccount.name | string | `"onepassword-connect-operator"` | The name of the 1Password Conenct Operator |
 | operator.version | string | `"1.0.0"` | T 1Password Connect Operator version to pull |
 | operator.token.key | string | `"token"` | The key for the 1Password Connect token stored in the 1Password token secret |
 | operator.token.name | string | `"onepassword-token"` | The name of Kubernetes Secret containing the 1Password Connect API token |
 | operator.token.value | string | `"onepassword-token"` | An API token generated for 1Password Connect to be used by the Connect Operator |
-| operator.watchNamespace | {} | [`{{ .Release.Namespace }}`] | A list of Namespaces for the 1Password Connect Operator to watch and manage |
+| operator.watchNamespace | {} | [`{{.Release.Namespace}}`] | A list of Namespaces for the 1Password Connect Operator to watch and manage |
 
 ### CRD
 


### PR DESCRIPTION
Even though curly braces with spaces is more standard, removing these spaces bypasses line breaks, which makes it more readable.