### PR TITLE
Release connect chart v1.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release charts if needed
 
-on: workflow_dispatch
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@
 
 ---
 
+[//]: # (START/v1.2.0)
+# v1.2.0
+
+## Features
+  * New Helm repo URL: https://1password.github.io/connect-helm-charts {#41}
+  * Connect server updated to `v1.1.0` {#40}
+  * Operator version updated to `v1.0.1` {#42}
+  * CRD now lives in `crds/` dir, so they can be skipped with the `--skip-crds` flag {#36}
+  * RBAC resources will be created by default when operator is enabled {#37}
+  * `.Release.Namespace` is now watched by the operator by default {#32}
+
+---
+
 [//]: # (START/v1.1.0)
 # v1.1.0
 

--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: connect
-version: 1.1.0
+version: 1.2.0
 description: A Helm chart for deploying 1Password Connect and the 1Password Connect Kubernetes Operator
 keywords:
   - "1Password"


### PR DESCRIPTION
### Features
  * New Helm repo URL: https://1password.github.io/connect-helm-charts {#41}
  * Connect server updated to `v1.1.0` {#40}
  * Operator version updated to `v1.0.1` {#42}
  * CRD now lives in `crds/` dir, so they can be skipped with the `--skip-crds` flag {#36}
  * RBAC resources will be created by default when operator is enabled {#37}
  * `.Release.Namespace` is now watched by the operator by default {#32}
