### PR TITLE
TLS support

### DIFF
--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
   - name: 1Password Secrets Integrations Team
     email: support+business@1password.com
 icon: https://avatars.githubusercontent.com/u/38230737
-appVersion: "1.1.0"
+appVersion: "1.2.0"

--- a/charts/connect/README.md
+++ b/charts/connect/README.md
@@ -50,6 +50,8 @@ $ helm install --set connect.applicationName=connect connect ./connect
 | connect.api.imageRepository | string | `"1password/connect-api` | The 1Password Connect API repository |
 | connect.api.name | string | `"connect-api"` | The name of the 1Password Connect API container |
 | connect.api.resources | object | `{}` | The resources requests/limits for the 1Password Connect API pod |
+| connect.api.httpPort | integer | `8080` | The port the Connect API is served on when TLS is disabled |
+| connect.api.httpsPort | integer | `8443` | The port the Connect API is served on when TLS is enabled |
 | connect.credentials | jsonString |  | Contents of the 1password-credentials.json file for Connect. Can be set be adding `--set-file connect.credentials=<path/to/1password-credentials.json>` to your helm install command |
 | connect.credentialsKey | string | `"op-session"` | The key for the 1Password Connect Credentials stored in the credentials secret |
 | connect.credentialsName | string | `"op-credentials"` | The name of Kubernetes Secret containing the 1Password Connect credentials |
@@ -61,6 +63,9 @@ $ helm install --set connect.applicationName=connect connect ./connect
 | connect.sync.imageRepository | string | `"1password/connect-sync` | The 1Password Connect Sync repository |
 | connect.sync.name | string | `"connect-sync"` | The name of the 1Password Connect Sync container |
 | connect.sync.resources | object | `{}` | The resources requests/limits for the 1Password Connect Sync pod |
+| connect.sync.httpPort | integer | `8081` | The port serving the health of the Sync container |
+| connect.tls.enabled | boolean | `false` | Denotes whether the Connect API is secured with TLS |
+| connect.tls.secret | string | `"op-connect-tls"` | The name of the secret containing the TLS key (`tls.key`) and certificate (`tls.crt`)  |
 | connect.version | string | `{{.Chart.AppVersion}}` | The 1Password Connect version to pull |
 | operator.autoRestart | boolean | `false` | Denotes whether the 1Password Connect Operator will automatically restart deployments based on associated updated secrets. |
 | operator.create | boolean | `false` | Denotes whether the 1Password Connect Operator will be deployed |

--- a/charts/connect/templates/_helpers.tpl
+++ b/charts/connect/templates/_helpers.tpl
@@ -40,9 +40,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "onepassword-connect.url" -}}
-{{- if .Values.connect.tls.enabled }}
+{{- if .Values.connect.tls.enabled -}}
 https://{{ .Values.connect.applicationName }}:{{ .Values.connect.api.httpsPort  }}
-{{- else }}
+{{- else -}}
 http://{{ .Values.connect.applicationName }}:{{ .Values.connect.api.httpPort  }}
 {{- end }}
 {{- end }}

--- a/charts/connect/templates/_helpers.tpl
+++ b/charts/connect/templates/_helpers.tpl
@@ -38,3 +38,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- $local := dict "first" true -}}
 {{- range $k, $v := . -}}{{- if not $local.first -}},{{- end -}}{{- $v -}}{{- $_ := set $local "first" false -}}{{- end -}}
 {{- end -}}
+
+{{- define "onepassword-connect.url" -}}
+{{- if .Values.connect.tls.enabled }}
+https://{{ .Values.connect.applicationName }}:{{ .Values.connect.api.httpsPort  }}
+{{- else }}
+http://{{ .Values.connect.applicationName }}:{{ .Values.connect.api.httpPort  }}
+{{- end }}
+{{- end }}

--- a/charts/connect/templates/connect-deployment.yaml
+++ b/charts/connect/templates/connect-deployment.yaml
@@ -25,6 +25,11 @@ spec:
         - name: credentials
           secret:
             secretName: {{ .Values.connect.credentialsName }}
+        {{- if .Values.connect.tls.enabled }}
+        - name: tls-cert
+          secret:
+            secretName: {{ .Values.connect.tls.secret }}
+        {{- end }}
       initContainers:
         - name: sqlite-permissions
           image: alpine:3.12
@@ -59,9 +64,19 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.connect.credentialsName }}
                   key: {{ .Values.connect.credentialsKey }}
+            {{- if .Values.connect.tls.enabled }}
+            - name: OP_TLS_CERT_FILE
+              value: /home/opuser/.op/certs/tls.crt
+            - name: OP_TLS_KEY_FILE
+              value: /home/opuser/.op/certs/tls.key
+            {{- end }}
           volumeMounts:
             - mountPath: /home/opuser/.op/data
               name: {{ .Values.connect.dataVolume.name }}
+            {{- if .Values.connect.tls.enabled }}
+            - name: tls-cert
+              mountPath: /home/opuser/.op/certs
+            {{- end }}
         - name: connect-sync
           image: {{ .Values.connect.sync.imageRepository }}:{{ tpl .Values.connect.version . }}
           imagePullPolicy: {{ .Values.connect.imagePullPolicy }}

--- a/charts/connect/templates/connect-deployment.yaml
+++ b/charts/connect/templates/connect-deployment.yaml
@@ -56,8 +56,6 @@ spec:
               - "NET_BROADCAST"
           resources:
             {{- toYaml .Values.connect.sync.resources | nindent 12 }}
-          ports:
-            - containerPort: 8080
           env:
             - name: OP_SESSION
               valueFrom:
@@ -96,8 +94,6 @@ spec:
               - "NET_BROADCAST"
           resources:
             {{- toYaml .Values.connect.sync.resources | nindent 12 }}
-          ports:
-            - containerPort: 8081
           env:
             - name: OP_HTTP_PORT
               value: "{{ .Values.connect.sync.httpPort }}"

--- a/charts/connect/templates/connect-deployment.yaml
+++ b/charts/connect/templates/connect-deployment.yaml
@@ -69,6 +69,11 @@ spec:
               value: /home/opuser/.op/certs/tls.crt
             - name: OP_TLS_KEY_FILE
               value: /home/opuser/.op/certs/tls.key
+            - name: OP_HTTPS_PORT
+              value: "{{ .Values.connect.api.httpsPort }}"
+            {{- else }}
+            - name: OP_HTTP_PORT
+              value: "{{ .Values.connect.api.httpPort }}"
             {{- end }}
           volumeMounts:
             - mountPath: /home/opuser/.op/data
@@ -95,7 +100,7 @@ spec:
             - containerPort: 8081
           env:
             - name: OP_HTTP_PORT
-              value: "8081"
+              value: "{{ .Values.connect.sync.httpPort }}"
             - name: OP_SESSION
               valueFrom:
                 secretKeyRef:

--- a/charts/connect/templates/operator-deployment.yaml
+++ b/charts/connect/templates/operator-deployment.yaml
@@ -43,7 +43,7 @@ spec:
             - name: OPERATOR_NAME
               value: "{{ .Values.operator.applicationName }}"
             - name: OP_CONNECT_HOST
-              value: "http://{{ .Values.connect.applicationName }}:8080"
+              value: "{{- include "onepassword-connect.url" . }}"
             - name: POLLING_INTERVAL
               value: "{{ .Values.operator.pollingInterval }}"
             - name: OP_CONNECT_TOKEN

--- a/charts/connect/templates/service.yaml
+++ b/charts/connect/templates/service.yaml
@@ -10,11 +10,12 @@ spec:
   selector:
     app: {{ .Values.connect.applicationName }}
   ports:
-    - port: 8080
-      name: {{ .Values.connect.api.name }}
-    - port: 8081
+    - port: {{ .Values.connect.sync.httpPort }}
       name: {{ .Values.connect.sync.name }}
     {{- if .Values.connect.tls.enabled }}
-    - port: 8443
+    - port: {{ .Values.connect.api.httpsPort }}
       name: {{ .Values.connect.api.name }}-https
+    {{- else }}
+    - port: {{ .Values.connect.api.httpPort }}
+      name: {{ .Values.connect.api.name }}
     {{- end }}

--- a/charts/connect/templates/service.yaml
+++ b/charts/connect/templates/service.yaml
@@ -14,3 +14,7 @@ spec:
       name: {{ .Values.connect.api.name }}
     - port: 8081
       name: {{ .Values.connect.sync.name }}
+    {{- if .Values.connect.tls.enabled }}
+    - port: 8443
+      name: {{ .Values.connect.api.name }}-https
+    {{- end }}

--- a/charts/connect/templates/tests/health-check.yml
+++ b/charts/connect/templates/tests/health-check.yml
@@ -13,4 +13,4 @@ spec:
   containers:
     - name: curl
       image: curlimages/curl
-      command: ["curl", "http://{{ .Values.connect.applicationName }}:8080/health"]
+      command: ["curl", "{{- include "onepassword-connect.url" . }}/health"]

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -15,6 +15,9 @@ connect:
   credentialsName: op-credentials
   credentialsKey: 1password-credentials.json
   credentials:
+  tls:
+    enabled: false
+    secret: op-connect-tls
   dataVolume:
     name: shared-data
     type: emptyDir

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -8,10 +8,13 @@ connect:
     name: connect-api
     imageRepository: 1password/connect-api
     resources: {}
+    httpPort: 8080
+    httpsPort: 8443
   sync:
     name: connect-sync
     imageRepository: 1password/connect-sync
     resources: {}
+    httpPort: 8081
   credentialsName: op-credentials
   credentialsKey: 1password-credentials.json
   credentials:


### PR DESCRIPTION
Exposes `connect.tls.enabled` and `connect.tls.secret` to enable TLS for the Connect server. The `connect.tls.secret` should contain the name of a secret that contains `tls.key` and `tls.crt` value (as is standard for TLS configuration in Kubernetes).

One point for consideration: do we want to use `connect.tls.secret` or `connect.tls.secretName`?