### PR TITLE
Add readiness and liveness probes to Connect API

### DIFF
--- a/charts/connect/README.md
+++ b/charts/connect/README.md
@@ -58,6 +58,8 @@ $ helm install --set connect.applicationName=connect connect ./connect
 | connect.dataVolume.values | object | `{}` | Desribes the fields and values for configuration of shared volume for 1Password Connect |
 | connect.imagePullPolicy | string | `"IfNotPresent` | The 1Password Connect API image pull policy |
 | connect.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) stanza for the Connect pod |
+| connect.probes.readiness | boolean | `true` | Denotes whether the 1Password Connect API readiness probe will operate and ensure the pod is ready before serving traffic |
+| connect.probes.liveness | boolean | `true` | Denotes whether the 1Password Connect API will be continually checked by Kubernetes for liveness and restarted if the pod becomes unresponsive |
 | connect.sync.imageRepository | string | `"1password/connect-sync` | The 1Password Connect Sync repository |
 | connect.sync.name | string | `"connect-sync"` | The name of the 1Password Connect Sync container |
 | connect.sync.resources | object | `{}` | The resources requests/limits for the 1Password Connect Sync pod |

--- a/charts/connect/templates/connect-deployment.yaml
+++ b/charts/connect/templates/connect-deployment.yaml
@@ -59,6 +59,20 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.connect.credentialsName }}
                   key: {{ .Values.connect.credentialsKey }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            failureThreshold: 3
+            periodSeconds: 30
+            initialDelaySeconds: 15
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            failureThreshold: 3
+            periodSeconds: 30
+            initialDelaySeconds: 15
           volumeMounts:
             - mountPath: /home/opuser/.op/data
               name: {{ .Values.connect.dataVolume.name }}
@@ -78,6 +92,22 @@ spec:
             {{- toYaml .Values.connect.sync.resources | nindent 12 }}
           ports:
             - containerPort: 8081
+          {{- if .Values.connect.probes.readiness }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 15
+          {{ end }}
+          {{- if .Values.connect.probes.liveness }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            failureThreshold: 3
+            periodSeconds: 30
+            initialDelaySeconds: 15
+          {{ end }}
           env:
             - name: OP_HTTP_PORT
               value: "8081"

--- a/charts/connect/templates/connect-deployment.yaml
+++ b/charts/connect/templates/connect-deployment.yaml
@@ -59,13 +59,14 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.connect.credentialsName }}
                   key: {{ .Values.connect.credentialsKey }}
+          {{- if .Values.connect.probes.readiness }}
           readinessProbe:
             httpGet:
               path: /health
               port: 8080
-            failureThreshold: 3
-            periodSeconds: 30
             initialDelaySeconds: 15
+          {{ end }}
+          {{- if .Values.connect.probes.liveness }}
           livenessProbe:
             httpGet:
               path: /health
@@ -73,6 +74,7 @@ spec:
             failureThreshold: 3
             periodSeconds: 30
             initialDelaySeconds: 15
+          {{ end }}
           volumeMounts:
             - mountPath: /home/opuser/.op/data
               name: {{ .Values.connect.dataVolume.name }}

--- a/charts/connect/templates/connect-deployment.yaml
+++ b/charts/connect/templates/connect-deployment.yaml
@@ -69,7 +69,7 @@ spec:
           {{- if .Values.connect.probes.liveness }}
           livenessProbe:
             httpGet:
-              path: /health
+              path: /heartbeat
               port: 8080
             failureThreshold: 3
             periodSeconds: 30
@@ -104,7 +104,7 @@ spec:
           {{- if .Values.connect.probes.liveness }}
           livenessProbe:
             httpGet:
-              path: /health
+              path: /heartbeat
               port: 8080
             failureThreshold: 3
             periodSeconds: 30

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -22,6 +22,9 @@ connect:
   imagePullPolicy: IfNotPresent
   version: "{{ .Chart.AppVersion }}"
   nodeSelector: {}
+  probes:
+    liveness: true
+    readiness: true
 
 operator:
   create: false


### PR DESCRIPTION
I've added some readiness and liveness probes to the connect API pods. 

The operator doesn't appear to have a /health or /heartbeat endpoint so I haven't added any probes to it. 