### PR TITLE
Offer additional labels & annatations for deployments

### DIFF
--- a/charts/connect/README.md
+++ b/charts/connect/README.md
@@ -58,6 +58,10 @@ $ helm install --set connect.applicationName=connect connect ./connect
 | connect.dataVolume.values | object | `{}` | Desribes the fields and values for configuration of shared volume for 1Password Connect |
 | connect.imagePullPolicy | string | `"IfNotPresent` | The 1Password Connect API image pull policy |
 | connect.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) stanza for the Connect pod |
+| connect.annotations | object | `{}` | Additional annotations to be added to the Connect API deployment resource. |
+| connect.labels | object | `{}` | Additional labels to be added to the Connect API deployment resource. |
+| connect.podAnnotations | object | `{}` | Additional annotations to be added to the Connect API pods. |
+| connect.podLabels | object | `{}` | Additional labels to be added to the Connect API pods.  |
 | connect.sync.imageRepository | string | `"1password/connect-sync` | The 1Password Connect Sync repository |
 | connect.sync.name | string | `"connect-sync"` | The name of the 1Password Connect Sync container |
 | connect.sync.resources | object | `{}` | The resources requests/limits for the 1Password Connect Sync pod |
@@ -67,6 +71,10 @@ $ helm install --set connect.applicationName=connect connect ./connect
 | operator.imagePullPolicy | string | `"IfNotPresent` | The 1Password Connect Operator image pull policy |
 | operator.imageRepository | string | `"1password/onepassword-operator` | The 1Password Connect Operator repository |
 | operator.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) stanza for the operator pod |
+| operator.annotations | object | `{}` | Additional annotations to be added to the Operator deployment resource. |
+| operator.labels | object | `{}` | Additional labels to be added to the Operator deployment resource. |
+| operator.podAnnotations | object | `{}` | Additional annotations to be added to the Operator pods. |
+| operator.podLabels | object | `{}` | Additional labels to be added to the Operator pods.  |
 | operator.pollingInterval | integer | `600` | How often the 1Password Connect Operator will poll for secrets updates. |
 | operator.clusterRole.create | boolean | `{{.Values.operator.create}}` | Denotes whether or not a cluster role will be created for each for the 1Password Connect Operator |
 | operator.clusterRole.name | string | `"onepassword-connect-operator"` | The name of the 1Password Connect Operator Cluster Role |

--- a/charts/connect/templates/connect-deployment.yaml
+++ b/charts/connect/templates/connect-deployment.yaml
@@ -5,6 +5,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "onepassword-connect.labels" . | nindent 4 }}
+  {{- with .Values.connect.labels }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  annotations:
+  {{- with .Values.connect.annotations }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -14,6 +21,13 @@ spec:
       labels:
         app: {{ .Values.connect.applicationName }}
         version: "{{ tpl .Values.connect.version . }}"
+      {{- with .Values.connect.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      annotations:
+      {{- with .Values.connect.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
 {{- with .Values.connect.nodeSelector }}
       nodeSelector:

--- a/charts/connect/templates/connect-deployment.yaml
+++ b/charts/connect/templates/connect-deployment.yaml
@@ -8,8 +8,8 @@ metadata:
   {{- with .Values.connect.labels }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
-  annotations:
   {{- with .Values.connect.annotations }}
+  annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
@@ -24,8 +24,8 @@ spec:
       {{- with .Values.connect.podLabels }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      annotations:
       {{- with .Values.connect.podAnnotations }}
+      annotations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:

--- a/charts/connect/templates/operator-deployment.yaml
+++ b/charts/connect/templates/operator-deployment.yaml
@@ -9,8 +9,8 @@ metadata:
   {{- with .Values.operator.labels }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
-  annotations:
   {{- with .Values.operator.annotations }}
+  annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
@@ -25,8 +25,8 @@ spec:
       {{- with .Values.operator.podLabels }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      annotations:
       {{- with .Values.operator.podAnnotations }}
+      annotations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:

--- a/charts/connect/templates/operator-deployment.yaml
+++ b/charts/connect/templates/operator-deployment.yaml
@@ -6,6 +6,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "onepassword-connect.labels" . | nindent 4 }}
+  {{- with .Values.operator.labels }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  annotations:
+  {{- with .Values.operator.annotations }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   selector:
@@ -15,6 +22,13 @@ spec:
     metadata:
       labels:
         name: {{ .Values.connect.applicationName }}
+      {{- with .Values.operator.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      annotations:
+      {{- with .Values.operator.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
 {{- with .Values.operator.nodeSelector }}
       nodeSelector:

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -22,6 +22,10 @@ connect:
   imagePullPolicy: IfNotPresent
   version: "{{ .Chart.AppVersion }}"
   nodeSelector: {}
+  annotations: {}
+  labels: {}
+  podAnnotations: {}
+  podLabels: {}
 
 operator:
   create: false
@@ -32,6 +36,10 @@ operator:
   pollingInterval: 10
   version: "1.0.1"
   nodeSelector: {}
+  annotations: {}
+  labels: {}
+  podAnnotations: {}
+  podLabels: {}
   watchNamespace:
     - "{{ .Release.Namespace }}"
   token:


### PR DESCRIPTION
In some use-cases, labels and annotations are used for enhanced monitoring, Prometheus scraping etc. 

So this adds 4 new values. 

Deployment Annotation & Labels -i.e. for the deployment resource itself
Pod Annotation & Labels - i.e. added to the template and these are passed down to the pod created by the deployment. 

An example values.yaml:

```
  nodeSelector: {}
  annotations: {}
  labels: {}
  podAnnotations:
    prometheus.io/port: "8080"
    prometheus.io/scrape: "true"
  podLabels: {}
```