### PR TITLE
Add support for on-demand CI acceptance test runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,15 @@ name: Run acceptance tests
 on:
   push:
 
-  # Workflow dispatch listener to enable on-demand acceptance test runs on external PRs
+  # Workflow dispatch listener to enable on-demand acceptance test runs on external PRs.
+  # How to use this:
+  # * Do a sanity check on the submitted PR
+  # * Copy the most recent commit hash of the PR branch
+  # * Go to 'Actions' -> 'Run acceptance tests' -> 'Run workflow'
+  # * Fill in the following:
+  #   * `checkout-repo`: `<PR author>/connect-helm-charts`
+  #   * `checkout-ref`: <copied commit hash>
+  #   * `branch`: `acceptance-tests-on-forks`
   workflow_dispatch:
     inputs:
       checkout-repo:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,14 @@
 name: Run acceptance tests
-on: [push]
+on:
+  push:
+
+  # Workflow dispatch listener to enable on-demand acceptance test runs on external PRs
+  workflow_dispatch:
+    inputs:
+      checkout-repo:
+        required: false
+      checkout-ref:
+        required: false
 
 jobs:
   test:
@@ -9,6 +18,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          repository: ${{ github.event.inputs.checkout-repo }}
+          ref: ${{ github.event.inputs.checkout-ref }}
 
       - name: Set up Helm
         uses: azure/setup-helm@v1


### PR DESCRIPTION
Not so pretty, but a better-than-nothing solution to be able to run the acceptance tests for external PRs after having manually validated them.

### Usage
Do a manual sanity check on the submitted code and copy the branch's latest commit hash, go to the `Actions` tab -> `Run acceptance tests` and press the `Run workflow` button (note: button doesn't show yet, because this PR needs to be on `main` first). Paste in the commit hash you verified and enter the fork repository name, and it will run the acceptance tests including the secrets needed to run the tests.

![image](https://user-images.githubusercontent.com/7430639/121012621-313d7600-c798-11eb-86ce-0e3391076d1d.png)

### Downsides of this approach:
- No automatic reporting back to the PR
- We have to keep a branch / commit open to attach all the workflow runs to, to avoid messing up our main branch commits with false alarm red Xs. I've created [`acceptance-tests-on-forks`](https://github.com/1Password/connect-helm-charts/tree/acceptance-tests-on-forks) for this purpose.

If GitHub ever releases an `Approve workflow run with secrets` button for external PRs, then we can revert this PR.