### PR TITLE
Follow principle of least privilege for operator permissions

### DIFF
--- a/charts/connect/templates/rolebinding.yaml
+++ b/charts/connect/templates/rolebinding.yaml
@@ -2,9 +2,10 @@
 {{- $name := .Values.operator.roleBinding.name -}}
 {{- $clusterRoleName := .Values.operator.clusterRole.name -}}
 {{- $serviceAccountName := .Values.operator.serviceAccount.name -}}
+{{- $releaseNamespace := .Release.Namespace -}}
 {{- range $namespace := .Values.operator.watchNamespace }}
 {{- $namespace = tpl $namespace $ -}}
-kind: ClusterRoleBinding
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ $name }}-{{ $namespace }}
@@ -14,7 +15,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ $serviceAccountName }}
-  namespace: {{ $namespace }}
+  namespace: {{ $releaseNamespace }}
 roleRef:
   kind: ClusterRole
   name: {{ $clusterRoleName}}

--- a/charts/connect/templates/serviceaccount.yaml
+++ b/charts/connect/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.operator.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "onepassword-connect.labels" . | nindent 4 }}
   {{- with .Values.operator.serviceAccount.annotations }}


### PR DESCRIPTION
`ClusterRoleBinding` grants the permissions cluster wide. Instead, now we limit the permissions to just the namespaces being  watched by using a `RoleBinding` instead following the principle of least privilege.

### References
- https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding