### PR TITLE
Make Connect Service k8s resource type configurable

### DIFF
--- a/charts/connect/README.md
+++ b/charts/connect/README.md
@@ -66,6 +66,7 @@ $ helm install --set connect.applicationName=connect connect ./connect
 | connect.labels | object | `{}` | Additional labels to be added to the Connect API deployment resource. |
 | connect.podAnnotations | object | `{}` | Additional annotations to be added to the Connect API pods. |
 | connect.podLabels | object | `{}` | Additional labels to be added to the Connect API pods.  |
+| connect.serviceType | string | `NodePort` | The type of Service resource to create for the Connect API and sync services. |
 | connect.sync.imageRepository | string | `"1password/connect-sync` | The 1Password Connect Sync repository |
 | connect.sync.name | string | `"connect-sync"` | The name of the 1Password Connect Sync container |
 | connect.sync.resources | object | `{}` | The resources requests/limits for the 1Password Connect Sync pod |

--- a/charts/connect/templates/service.yaml
+++ b/charts/connect/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "onepassword-connect.labels" . | nindent 4 }}
 spec:
-  type: NodePort
+  type: {{ .Values.connect.serviceType }}
   selector:
     app: {{ .Values.connect.applicationName }}
   ports:

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -71,10 +71,6 @@ operator:
     create: "{{ .Values.operator.create }}"
     name: onepassword-connect-operator
 
-service:
-  type: Nodeport
-  port: 8080
-
 acceptanceTests:
   enabled: false
   fixtures: {}

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -15,6 +15,7 @@ connect:
     imageRepository: 1password/connect-sync
     resources: {}
     httpPort: 8081
+  serviceType: NodePort
   credentialsName: op-credentials
   credentialsKey: 1password-credentials.json
   credentials:


### PR DESCRIPTION
I noticed the connect chart had default values for `service.type` and `service.port` that went unused. Having the ability to create a `ClusterIP` service for use inside our cluster only rather than `NodePort` exposed on the node IPs better fits our use case.

This PR cleans up the unused `service.*` default values and adds `connect.serviceType`, defaulted to `NodePort` to match the hardcoded value, for this purpose.