### PR TITLE
Watch all namespaces for secrets (attempt 2)

### DIFF
--- a/charts/connect/README.md
+++ b/charts/connect/README.md
@@ -75,7 +75,6 @@ $ helm install --set connect.applicationName=connect connect ./connect
 | connect.version | string | `{{.Chart.AppVersion}}` | The 1Password Connect version to pull |
 | operator.autoRestart | boolean | `false` | Denotes whether the 1Password Connect Operator will automatically restart deployments based on associated updated secrets. |
 | operator.create | boolean | `false` | Denotes whether the 1Password Connect Operator will be deployed |
-| operator.watchallNamespaces | boolean | `true` | Denotes whether the 1Password Connect Operator will be watching all namespaces for secrets |
 | operator.imagePullPolicy | string | `"IfNotPresent` | The 1Password Connect Operator image pull policy |
 | operator.imageRepository | string | `"1password/onepassword-operator` | The 1Password Connect Operator repository |
 | operator.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) stanza for the operator pod |
@@ -86,7 +85,7 @@ $ helm install --set connect.applicationName=connect connect ./connect
 | operator.pollingInterval | integer | `600` | How often the 1Password Connect Operator will poll for secrets updates. |
 | operator.clusterRole.create | boolean | `{{.Values.operator.create}}` | Denotes whether or not a cluster role will be created for each for the 1Password Connect Operator |
 | operator.clusterRole.name | string | `"onepassword-connect-operator"` | The name of the 1Password Connect Operator Cluster Role |
-| operator.clusterRoleBinding.create | boolean | `{{.Values.operator.watchallNamespaces}}` | Denotes whether or not a Cluster role binding will be created for the 1Password Connect Operator Service Account |
+| operator.clusterRoleBinding.create | boolean | `{{.Values.operator.create}}` | Denotes whether or not a Cluster role binding will be created for the 1Password Connect Operator Service Account |
 | operator.roleBinding.create | boolean | `{{.Values.operator.create}}` | Denotes whether or not a role binding will be created for each Namespace for the 1Password Connect Operator Service Account |
 | operator.roleBinding.name | string | `"onepassword-connect-operator"` | The name of the 1Password Connect Operator Role Binding |
 | operator.serviceAccount.annotations | object | `{}` | Annotations for the 1Password Connect Service Account |
@@ -96,7 +95,7 @@ $ helm install --set connect.applicationName=connect connect ./connect
 | operator.token.key | string | `"token"` | The key for the 1Password Connect token stored in the 1Password token secret |
 | operator.token.name | string | `"onepassword-token"` | The name of Kubernetes Secret containing the 1Password Connect API token |
 | operator.token.value | string | `"onepassword-token"` | An API token generated for 1Password Connect to be used by the Connect Operator |
-| operator.watchNamespace | list | `[]` | A list of Namespaces for the 1Password Connect Operator to watch and manage |
+| operator.watchNamespace | list | `[]` | A list of namespaces for the 1Password Connect Operator to watch and manage. Use the empty list to watch all namespaces. |
 | operator.resources | object | `{}` | The resources requests/limits for the 1Password Connect Operator pod |
 
 ### CRD

--- a/charts/connect/README.md
+++ b/charts/connect/README.md
@@ -75,6 +75,7 @@ $ helm install --set connect.applicationName=connect connect ./connect
 | connect.version | string | `{{.Chart.AppVersion}}` | The 1Password Connect version to pull |
 | operator.autoRestart | boolean | `false` | Denotes whether the 1Password Connect Operator will automatically restart deployments based on associated updated secrets. |
 | operator.create | boolean | `false` | Denotes whether the 1Password Connect Operator will be deployed |
+| operator.watchallNamespaces | boolean | `true` | Denotes whether the 1Password Connect Operator will be watching all namespaces for secrets |
 | operator.imagePullPolicy | string | `"IfNotPresent` | The 1Password Connect Operator image pull policy |
 | operator.imageRepository | string | `"1password/onepassword-operator` | The 1Password Connect Operator repository |
 | operator.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) stanza for the operator pod |
@@ -85,6 +86,7 @@ $ helm install --set connect.applicationName=connect connect ./connect
 | operator.pollingInterval | integer | `600` | How often the 1Password Connect Operator will poll for secrets updates. |
 | operator.clusterRole.create | boolean | `{{.Values.operator.create}}` | Denotes whether or not a cluster role will be created for each for the 1Password Connect Operator |
 | operator.clusterRole.name | string | `"onepassword-connect-operator"` | The name of the 1Password Connect Operator Cluster Role |
+| operator.clusterRoleBinding.create | boolean | `{{.Values.operator.watchallNamespaces}}` | Denotes whether or not a Cluster role binding will be created for the 1Password Connect Operator Service Account |
 | operator.roleBinding.create | boolean | `{{.Values.operator.create}}` | Denotes whether or not a role binding will be created for each Namespace for the 1Password Connect Operator Service Account |
 | operator.roleBinding.name | string | `"onepassword-connect-operator"` | The name of the 1Password Connect Operator Role Binding |
 | operator.serviceAccount.annotations | object | `{}` | Annotations for the 1Password Connect Service Account |
@@ -94,7 +96,7 @@ $ helm install --set connect.applicationName=connect connect ./connect
 | operator.token.key | string | `"token"` | The key for the 1Password Connect token stored in the 1Password token secret |
 | operator.token.name | string | `"onepassword-token"` | The name of Kubernetes Secret containing the 1Password Connect API token |
 | operator.token.value | string | `"onepassword-token"` | An API token generated for 1Password Connect to be used by the Connect Operator |
-| operator.watchNamespace | {} | [`{{.Release.Namespace}}`] | A list of Namespaces for the 1Password Connect Operator to watch and manage |
+| operator.watchNamespace | list | `[]` | A list of Namespaces for the 1Password Connect Operator to watch and manage |
 | operator.resources | object | `{}` | The resources requests/limits for the 1Password Connect Operator pod |
 
 ### CRD

--- a/charts/connect/templates/clusterrolebinding.yaml
+++ b/charts/connect/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if eq (tpl (.Values.operator.create | toString) .) "true" -}}
-{{- if eq (tpl (.Values.operator.clusterRoleBinding.create | toString) .) "true" -}}
+{{- if not .Values.operator.watchNamespace -}}
 {{- $name := .Values.operator.clusterRoleBinding.name -}}
 {{- $clusterRoleName := .Values.operator.clusterRole.name -}}
 {{- $serviceAccountName := .Values.operator.serviceAccount.name -}}

--- a/charts/connect/templates/clusterrolebinding.yaml
+++ b/charts/connect/templates/clusterrolebinding.yaml
@@ -1,16 +1,13 @@
-{{- if eq (tpl (.Values.operator.roleBinding.create | toString) .) "true" -}}
-{{- if eq (tpl (.Values.operator.clusterRoleBinding.create | toString) .) "false" -}}
-{{- $name := .Values.operator.roleBinding.name -}}
+{{- if eq (tpl (.Values.operator.create | toString) .) "true" -}}
+{{- if eq (tpl (.Values.operator.clusterRoleBinding.create | toString) .) "true" -}}
+{{- $name := .Values.operator.clusterRoleBinding.name -}}
 {{- $clusterRoleName := .Values.operator.clusterRole.name -}}
 {{- $serviceAccountName := .Values.operator.serviceAccount.name -}}
 {{- $releaseNamespace := .Release.Namespace -}}
-{{- range $namespace := .Values.operator.watchNamespace }}
-{{- $namespace = tpl $namespace $ -}}
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ $name }}-{{ $namespace }}
-  namespace: {{ $namespace }}
+  name: {{ $name }}
   labels:
     {{- include "onepassword-connect.labels" $ | nindent 4 }}
 subjects:
@@ -19,9 +16,7 @@ subjects:
   namespace: {{ $releaseNamespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ $clusterRoleName}}
+  name: {{ $clusterRoleName }}
   apiGroup: rbac.authorization.k8s.io
----
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/connect/templates/operator-deployment.yaml
+++ b/charts/connect/templates/operator-deployment.yaml
@@ -49,7 +49,7 @@ spec:
           command: ["/manager"]
           env:
             - name: WATCH_NAMESPACE
-              value: {{ tpl (include "helm-toolkit.utils.joinListWithComma" .Values.operator.watchNamespace) . }}
+              value: {{ default "" (tpl (include "helm-toolkit.utils.joinListWithComma" .Values.operator.watchNamespace) .) }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -70,4 +70,3 @@ spec:
           resources:
             {{- toYaml .Values.operator.resources | nindent 12 }}
 {{- end }}
-

--- a/charts/connect/templates/rolebinding.yaml
+++ b/charts/connect/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if eq (tpl (.Values.operator.roleBinding.create | toString) .) "true" -}}
-{{- if eq (tpl (.Values.operator.clusterRoleBinding.create | toString) .) "false" -}}
+{{- if .Values.operator.watchNamespace -}}
 {{- $name := .Values.operator.roleBinding.name -}}
 {{- $clusterRoleName := .Values.operator.clusterRole.name -}}
 {{- $serviceAccountName := .Values.operator.serviceAccount.name -}}

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -39,6 +39,7 @@ connect:
 operator:
   create: false
   autoRestart: false
+  watchallNamespaces: true
   applicationName: onepassword-connect-operator
   imagePullPolicy: IfNotPresent
   imageRepository: 1password/onepassword-operator
@@ -49,8 +50,7 @@ operator:
   labels: {}
   podAnnotations: {}
   podLabels: {}
-  watchNamespace:
-    - "{{ .Release.Namespace }}"
+  watchNamespace: []
   resources: {}
   token:
     name: onepassword-token
@@ -68,6 +68,10 @@ operator:
 
   clusterRole:
     create: "{{ .Values.operator.create }}"
+    name: onepassword-connect-operator
+
+  clusterRoleBinding:
+    create: "{{ .Values.operator.watchallNamespaces }}"
     name: onepassword-connect-operator
 
 service:

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -39,7 +39,6 @@ connect:
 operator:
   create: false
   autoRestart: false
-  watchallNamespaces: true
   applicationName: onepassword-connect-operator
   imagePullPolicy: IfNotPresent
   imageRepository: 1password/onepassword-operator
@@ -71,7 +70,7 @@ operator:
     name: onepassword-connect-operator
 
   clusterRoleBinding:
-    create: "{{ .Values.operator.watchallNamespaces }}"
+    create: "{{ .Values.operator.create }}"
     name: onepassword-connect-operator
 
 service:


### PR DESCRIPTION
I needed this for something I was working on, but I noticed #62 was kinda stalled. Thanks to @rchenzheng for doing all of the hard work. This PR addresses the comments in #62.

This change creates a ClusterRoleBinding conditionally if all namespaces are to be watched. By default, all namespaces are watched, to match the default behaviour when deploying the operator. This behaviour can be explicitly opted into by specifying an empty list for `operator.watchNamespace`.


See also:
#54
https://github.com/1Password/onepassword-operator/pull/40