### PR TITLE
Add app.kubernetes.io/component labels for connect, operator

### DIFF
--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: connect
-version: 1.4.0
+version: 1.4.1
 description: A Helm chart for deploying 1Password Connect and the 1Password Connect Kubernetes Operator
 keywords:
   - "1Password"

--- a/charts/connect/templates/connect-credentials.yaml
+++ b/charts/connect/templates/connect-credentials.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ .Values.connect.credentialsName }}
   namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/component: connect
     {{- include "onepassword-connect.labels" . | nindent 4 }}
 type: Opaque
 stringData:

--- a/charts/connect/templates/connect-deployment.yaml
+++ b/charts/connect/templates/connect-deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ .Values.connect.applicationName }}
   namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/component: connect
     {{- include "onepassword-connect.labels" . | nindent 4 }}
   {{- with .Values.connect.labels }}
   {{- toYaml . | nindent 4 }}
@@ -21,6 +22,7 @@ spec:
       labels:
         app: {{ .Values.connect.applicationName }}
         version: "{{ tpl .Values.connect.version . }}"
+        app.kubernetes.io/component: connect
       {{- with .Values.connect.podLabels }}
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/connect/templates/operator-deployment.yaml
+++ b/charts/connect/templates/operator-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ .Values.operator.applicationName }}
   namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/component: operator
     {{- include "onepassword-connect.labels" . | nindent 4 }}
   {{- with .Values.operator.labels }}
   {{- toYaml . | nindent 4 }}
@@ -22,6 +23,7 @@ spec:
     metadata:
       labels:
         name: {{ .Values.connect.applicationName }}
+        app.kubernetes.io/component: operator
       {{- with .Values.operator.podLabels }}
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/connect/templates/operator-token.yaml
+++ b/charts/connect/templates/operator-token.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ .Values.operator.token.name }}
   namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/component: operator
     {{- include "onepassword-connect.labels" . | nindent 4 }}
 type: Opaque
 stringData:

--- a/charts/connect/templates/service.yaml
+++ b/charts/connect/templates/service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ .Values.connect.applicationName }}
   namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/component: connect
     {{- include "onepassword-connect.labels" . | nindent 4 }}
 spec:
   type: NodePort


### PR DESCRIPTION
Quick PR to add `app.kubernetes.io/component` labels to the `connect` / `operator` specific resources. This helps with following logs, filtering for pods, etc when you only need either the `connect` service or the `operator` service, but not both.