### PR TITLE
Correct resources value name

### DIFF
--- a/charts/connect/templates/connect-deployment.yaml
+++ b/charts/connect/templates/connect-deployment.yaml
@@ -71,7 +71,7 @@ spec:
               add:
               - "NET_BROADCAST"
           resources:
-            {{- toYaml .Values.connect.sync.resources | nindent 12 }}
+            {{- toYaml .Values.connect.api.resources | nindent 12 }}
           env:
             - name: OP_SESSION
               valueFrom:


### PR DESCRIPTION
Corrects the name of the value that's being references to get the resources block for the api container