### PR TITLE
Remove need for NET_BROADCAST

### DIFF
--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
   - name: 1Password Secrets Integrations Team
     email: support+business@1password.com
 icon: https://avatars.githubusercontent.com/u/38230737
-appVersion: "1.3.1"
+appVersion: "1.5.0"

--- a/charts/connect/templates/connect-deployment.yaml
+++ b/charts/connect/templates/connect-deployment.yaml
@@ -56,11 +56,6 @@ spec:
             runAsUser: 999
             runAsGroup: 999
             allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - all
-              add:
-              - "NET_BROADCAST"
           resources:
             {{- toYaml .Values.connect.api.resources | nindent 12 }}
           env:
@@ -69,6 +64,10 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.connect.credentialsName }}
                   key: {{ .Values.connect.credentialsKey }}
+            - name: OP_BUS_PORT
+              value: "11220"
+            - name: OP_BUS_PEERS
+              value: localhost:11221
             {{- if .Values.connect.tls.enabled }}
             - name: OP_TLS_CERT_FILE
               value: /home/opuser/.op/certs/tls.crt
@@ -112,11 +111,6 @@ spec:
             runAsUser: 999
             runAsGroup: 999
             allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - all
-              add:
-              - "NET_BROADCAST"
           resources:
             {{- toYaml .Values.connect.sync.resources | nindent 12 }}
           env:
@@ -127,6 +121,10 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.connect.credentialsName }}
                   key: {{ .Values.connect.credentialsKey }}
+            - name: OP_BUS_PORT
+              value: "11221"
+            - name: OP_BUS_PEERS
+              value: localhost:11220
           {{- if .Values.connect.probes.readiness }}
           readinessProbe:
             httpGet:


### PR DESCRIPTION
As requested in both https://github.com/1Password/connect/issues/22 and https://github.com/1Password/connect/issues/21, this removes the need for the containers to obtain the `NET_BROADCAST` capability by no longer depending on the auto-discovery of each other.

Bumps Connect to `1.5.0` to use the new `OP_BUS_PEERS` option.