### PR TITLE
Add support for passing `connect.credentials` as base64-encoded value

### DIFF
--- a/charts/connect/README.md
+++ b/charts/connect/README.md
@@ -53,6 +53,7 @@ $ helm install --set connect.applicationName=connect connect ./connect
 | connect.api.httpPort | integer | `8080` | The port the Connect API is served on when TLS is disabled |
 | connect.api.httpsPort | integer | `8443` | The port the Connect API is served on when TLS is enabled |
 | connect.credentials | jsonString |  | Contents of the 1password-credentials.json file for Connect. Can be set be adding `--set-file connect.credentials=<path/to/1password-credentials.json>` to your helm install command |
+| connect.credentials_base64 | string |  | Base64-encoded contents of the 1password-credentials.json file for Connect. This can be used instead of `connect.credentials` in case supplying raw JSON to `connect.credentials` leads to issues.  |
 | connect.credentialsKey | string | `"op-session"` | The key for the 1Password Connect Credentials stored in the credentials secret |
 | connect.credentialsName | string | `"op-credentials"` | The name of Kubernetes Secret containing the 1Password Connect credentials |
 | connect.dataVolume.name | string | `"shared-data"` | The name of the shared volume used between 1Password Connect Containers |

--- a/charts/connect/templates/connect-credentials.yaml
+++ b/charts/connect/templates/connect-credentials.yaml
@@ -1,4 +1,7 @@
-{{- if (.Values.connect.credentials) -}}
+{{- if or (.Values.connect.credentials) (.Values.connect.credentials_base64)  -}}
+{{- if and (.Values.connect.credentials) (.Values.connect.credentials_base64) -}}
+  {{- fail "Only one of connect.credentials and connect.credentials_base64 can be specified" -}}
+{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,5 +13,9 @@ metadata:
 type: Opaque
 stringData:
   {{ .Values.connect.credentialsKey }}: |-
-  {{ .Values.connect.credentials | b64enc | indent 2}}
+  {{- if (.Values.connect.credentials) }}
+  {{ .Values.connect.credentials | b64enc | indent 2 }}
+  {{- else }}
+  {{ .Values.connect.credentials_base64 | indent 2 }}
+  {{- end }}
 {{- end }}

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -19,6 +19,7 @@ connect:
   credentialsName: op-credentials
   credentialsKey: 1password-credentials.json
   credentials:
+  credentials_base64:
   tls:
     enabled: false
     secret: op-connect-tls


### PR DESCRIPTION
Resolves the issue brought up in #67 that Terraform has issues with providing the raw JSON value as input to the Helm chart.