### PR TITLE
Release connect-1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@
 
 ---
 
+[//]: # (START/v1.7.0)
+# v1.7.0
+
+## Features
+* Connect can now run with fully unprivileged containers. {#21,#22}
+* Tolerations can now be configured with `connect.tolerations` and `operator.tolerations`. {#63}
+* Resource type for the Connect Service is now configurable. {#65}
+* Updated Connect to v1.5.0. {#81}
+* Base64-encoded credentials can be supplied through `connect.credentials_base64` if passing raw JSON through `connect.credentials` leads to issues. {#67}
+
+## Fixes
+* Resources are now correctly passed to the Connect API container. {#79}
+
+---
+
 [//]: # (START/v1.6.0)
 # v1.6.0
 

--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: connect
-version: 1.6.0
+version: 1.7.0
 description: A Helm chart for deploying 1Password Connect and the 1Password Connect Kubernetes Operator
 keywords:
   - "1Password"

--- a/charts/connect/README.md
+++ b/charts/connect/README.md
@@ -20,7 +20,7 @@ Creation of a secret for the token can be automated by the Helm Chart by using `
 If you would prefer to create the token secret manually, the token can be saved as a Kubernetes secret using the following command:
 
 ```bash
-$ kubectl create secret generic <token-name> --from-literal=token=<OP_CONNECT_TOKEN> \ --namespace=<namespace>
+$ kubectl create secret generic <token-name> --from-literal=token=<OP_CONNECT_TOKEN> --namespace=<namespace>
 ```
 
 More information about 1Password Connect and how to generate a 1Password Connect API token can be found at https://support.1password.com/secrets-automation/.


### PR DESCRIPTION
## Features
* Connect can now run with fully unprivileged containers. {#21,#22}
* Tolerations can now be configured with `connect.tolerations` and `operator.tolerations`. {#63}
* Resource type for the Connect Service is now configurable. {#65}
* Updated Connect to [v1.5.0](https://github.com/1Password/connect/blob/main/CHANGELOG.md#v150). {#81}
* Base64-encoded credentials can be supplied through `connect.credentials_base64` if passing raw JSON through `connect.credentials` leads to issues. {#67}

## Fixes
* Resources are now correctly passed to the Connect API container. {#79}

Thanks to @rowa78, @parente, @mcmarkj for their code contributions! 🙌 