### PR TITLE
Hide warning about credentials if `connect.credentials_base64` is set

### DIFF
--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: connect
-version: 1.7.0
+version: 1.7.1
 description: A Helm chart for deploying 1Password Connect and the 1Password Connect Kubernetes Operator
 keywords:
   - "1Password"

--- a/charts/connect/templates/NOTES.txt
+++ b/charts/connect/templates/NOTES.txt
@@ -2,7 +2,7 @@
 {{- $namespace := .Release.Namespace -}}
 {{- $tokenName := .Values.operator.token.name -}}
 
-{{- if not ( or (lookup "v1" "Secret" ( $namespace ) ( $credentialsName )) (.Values.connect.credentials)) }}
+{{- if not ( or (lookup "v1" "Secret" ( $namespace ) ( $credentialsName )) (.Values.connect.credentials) (.Values.connect.credentials_base64)) }}
 ---------------------------------------------------------------------------------------------
  WARNING
 


### PR DESCRIPTION
Without this change the following warning is shown if `connect.credentials_base64` is used:
```
WARNING

    Using 1Password Connect in Kubernetes requires that a 1password-credentials.json file
    be stored as a Kubernetes Secret. This credentials file can be saved as a Kubernetes
    secret by using one of two methods:

    Add the following to your helm install command:

         --set-file connect.credentials={path/to/1password-credentials.json}

    This will allow for Helm to handle storing 1password-credentials.json as a secret
    for you.

    More information about 1Password Connect and how to generate a 1password-credentials.json
    file can be found at https://support.1password.com/secrets-automation/.
```