### PR TITLE
Update Connect to v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@
 
 ---
 
+[//]: # (START/v1.7.1)
+# v1.7.1
+
+## Fixes
+* Updated Connect to v1.5.1, which resolves several synchronization related issues.
+
+---
+
 [//]: # (START/v1.7.0)
 # v1.7.0
 

--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: connect
-version: 1.7.0
+version: 1.7.1
 description: A Helm chart for deploying 1Password Connect and the 1Password Connect Kubernetes Operator
 keywords:
   - "1Password"
@@ -11,4 +11,4 @@ maintainers:
   - name: 1Password Secrets Integrations Team
     email: support+business@1password.com
 icon: https://avatars.githubusercontent.com/u/38230737
-appVersion: "1.5.0"
+appVersion: "1.5.1"


### PR DESCRIPTION
Updates Connect to v1.5.1, which has the following updates:

[IMPROVED] Connect stays better in sync with 1Password when it experiences connection problems. 

[FIXED] Fixed synchronization of templates that could prevent Connect from starting after changing its credentials. 
[FIXED] Templates should now correctly synchronize to Connect after emptying Connect's database. 
[FIXED] Connect should no longer return a "failed to initialize database" error when upgrading from Connect v1.3.x.