### PR TITLE
Add missing end quotes

### DIFF
--- a/charts/connect/README.md
+++ b/charts/connect/README.md
@@ -2,11 +2,11 @@
 
 ## Deploying 1Password Connect
 Installing the Helm Chart with default configurations will deploy 1Password Connect in your default Namespace. However, Using 1Password Connect in Kubernetes requires that a 1password-credentials.json file be stored as a Kubernetes Secret. This credentials file can be saved as a Kubernetes secret by setting the file in your helm install command:
-            
+
 ```bash
 helm install connect 1password/connect --set-file connect.credentials=<path/to/1password-credentials.json>
 ```
-    
+
 More information about 1Password Connect and how to generate a 1password-credentials.json file can be found at https://support.1password.com/secrets-automation/.
 
 ## Deploying 1Password Connect Kubernetes Operator
@@ -32,12 +32,12 @@ The 1Password Connect Helm chart offers many configuration options for deploymen
 
 >To override values in a chart, use either the '--values' flag and pass in a file or use the '--set' flag and pass configuration from the command line, to force a string value use '--set-string'. In case a value is large and therefore you want not to use neither '--values' nor '--set', use '--set-file' to read the single large value from file.
 
-For example: 
+For example:
 ```bash
 $ helm install -f myvalues.yaml connect ./connect
 ```
 
-or 
+or
 
 ```bash
 $ helm install --set connect.applicationName=connect connect ./connect
@@ -59,7 +59,7 @@ $ helm install --set connect.applicationName=connect connect ./connect
 | connect.dataVolume.name | string | `"shared-data"` | The name of the shared volume used between 1Password Connect Containers |
 | connect.dataVolume.type | string | `"emptyDir"` | The type of the shared volume used between 1Password Connect Containers |
 | connect.dataVolume.values | object | `{}` | Desribes the fields and values for configuration of shared volume for 1Password Connect |
-| connect.imagePullPolicy | string | `"IfNotPresent` | The 1Password Connect API image pull policy |
+| connect.imagePullPolicy | string | `"IfNotPresent"` | The 1Password Connect API image pull policy |
 | connect.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) stanza for the Connect pod |
 | connect.probes.readiness | boolean | `true` | Denotes whether the 1Password Connect API readiness probe will operate and ensure the pod is ready before serving traffic |
 | connect.probes.liveness | boolean | `true` | Denotes whether the 1Password Connect API will be continually checked by Kubernetes for liveness and restarted if the pod becomes unresponsive |
@@ -68,7 +68,7 @@ $ helm install --set connect.applicationName=connect connect ./connect
 | connect.podAnnotations | object | `{}` | Additional annotations to be added to the Connect API pods. |
 | connect.podLabels | object | `{}` | Additional labels to be added to the Connect API pods.  |
 | connect.serviceType | string | `NodePort` | The type of Service resource to create for the Connect API and sync services. |
-| connect.sync.imageRepository | string | `"1password/connect-sync` | The 1Password Connect Sync repository |
+| connect.sync.imageRepository | string | `"1password/connect-sync"` | The 1Password Connect Sync repository |
 | connect.sync.name | string | `"connect-sync"` | The name of the 1Password Connect Sync container |
 | connect.sync.resources | object | `{}` | The resources requests/limits for the 1Password Connect Sync pod |
 | connect.sync.httpPort | integer | `8081` | The port serving the health of the Sync container |
@@ -78,8 +78,8 @@ $ helm install --set connect.applicationName=connect connect ./connect
 | connect.version | string | `{{.Chart.AppVersion}}` | The 1Password Connect version to pull |
 | operator.autoRestart | boolean | `false` | Denotes whether the 1Password Connect Operator will automatically restart deployments based on associated updated secrets. |
 | operator.create | boolean | `false` | Denotes whether the 1Password Connect Operator will be deployed |
-| operator.imagePullPolicy | string | `"IfNotPresent` | The 1Password Connect Operator image pull policy |
-| operator.imageRepository | string | `"1password/onepassword-operator` | The 1Password Connect Operator repository |
+| operator.imagePullPolicy | string | `"IfNotPresent"` | The 1Password Connect Operator image pull policy |
+| operator.imageRepository | string | `"1password/onepassword-operator"` | The 1Password Connect Operator repository |
 | operator.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) stanza for the operator pod |
 | operator.annotations | object | `{}` | Additional annotations to be added to the Operator deployment resource. |
 | operator.labels | object | `{}` | Additional labels to be added to the Operator deployment resource. |


### PR DESCRIPTION
Add ending quote to the configuration default values for several options and cleaned up some trailing spaces.