### PR TITLE
Prepare release of connect-1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,25 @@
 # Latest
 
 ## Features
-  * A user-friendly description of a new feature. {issue-number}
+* A user-friendly description of a new feature. {issue-number}
 
 ## Fixes
- * A user-friendly description of a fix. {issue-number}
+* A user-friendly description of a fix. {issue-number}
 
 ## Security
- * A user-friendly description of a security fix. {issue-number}
+* A user-friendly description of a security fix. {issue-number}
+
+---
+
+[//]: # (START/v1.8.0)
+# Latest
+
+## Features
+* Updated Kubernetes Operator to v1.5.0, which adds the `type` and `status` for the `OnePasswordItem` CRD. {#101}
+* Updated OnePasswordItem CRD to enable the new functionality added in the latest version of the Kubernetes Operator. {#92, #102}
+
+## Fixes
+* Updated Connect to v1.5.4, which resolves some bugs. {#101}
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ## Features
 * Updated Kubernetes Operator to v1.5.0, which adds the `type` and `status` for the `OnePasswordItem` CRD. {#101}
-* Updated OnePasswordItem CRD to enable the new functionality added in the latest version of the Kubernetes Operator. {#92, #102}
+* Updated OnePasswordItem CRD to enable the new functionality added in the latest version of the Kubernetes Operator. Shoutout to @tomjohnburton for contributing to this enhancement. {#92, #102}
 
 ## Fixes
 * Updated Connect to v1.5.4, which resolves some bugs. {#101}

--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: connect
-version: 1.7.1
+version: 1.8.0
 description: A Helm chart for deploying 1Password Connect and the 1Password Connect Kubernetes Operator
 keywords:
   - "1Password"


### PR DESCRIPTION
## Features
* Updated Kubernetes Operator to v1.5.0, which adds the `type` and `status` for the `OnePasswordItem` CRD. {#101}
* Updated OnePasswordItem CRD to enable the new functionality added in the latest version of the Kubernetes Operator. Shoutout to @tomjohnburton for contributing to this enhancement. {#92, #102}

## Fixes
* Updated Connect to v1.5.4, which resolves some bugs. {#101}