### PR TITLE
Update Connect to v1.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,16 @@
 
 ---
 
+[//]: # (START/v1.8.1)
+# v1.8.1
+
+## Fixes
+* Updated Connect to v1.5.5, which addresses some bugs.
+
+---
+
 [//]: # (START/v1.8.0)
-# Latest
+# v.1.8.0
 
 ## Features
 * Updated Kubernetes Operator to v1.5.0, which adds the `type` and `status` for the `OnePasswordItem` CRD. {#101}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 # v1.8.1
 
 ## Fixes
-* Updated Connect to v1.5.5, which addresses some bugs.
+* Updated Connect to v1.5.6, which addresses some bugs.
 
 ---
 

--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
   - name: 1Password Secrets Integrations Team
     email: support+business@1password.com
 icon: https://avatars.githubusercontent.com/u/38230737
-appVersion: "1.5.5"
+appVersion: "1.5.6"

--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: connect
-version: 1.8.0
+version: 1.8.1
 description: A Helm chart for deploying 1Password Connect and the 1Password Connect Kubernetes Operator
 keywords:
   - "1Password"
@@ -11,4 +11,4 @@ maintainers:
   - name: 1Password Secrets Integrations Team
     email: support+business@1password.com
 icon: https://avatars.githubusercontent.com/u/38230737
-appVersion: "1.5.4"
+appVersion: "1.5.5"


### PR DESCRIPTION
Updates Connect to v1.5.6, which has the following updates (from v1.5.4):

- [FIXED] Connect now properly returns the `content_path` attribute of the File object.
- [FIXED] The file objects now have the correct ID and name.
- [FIXED] Categories route will no longer return status 500 when no error is present.
- [SECURITY] Updated Debian packages for the Docker release images.

This will also release 1.8.1 of the Connect Helm chart