### PR TITLE
fix: credential secret does not works if set from values

### DIFF
--- a/charts/connect/templates/connect-credentials.yaml
+++ b/charts/connect/templates/connect-credentials.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: connect
     {{- include "onepassword-connect.labels" . | nindent 4 }}
 type: Opaque
-stringData:
+data:
   {{ .Values.connect.credentialsKey }}: |-
   {{- if (.Values.connect.credentials) }}
   {{ .Values.connect.credentials | b64enc | indent 2 }}

--- a/charts/connect/templates/connect-deployment.yaml
+++ b/charts/connect/templates/connect-deployment.yaml
@@ -41,6 +41,9 @@ spec:
         - name: credentials
           secret:
             secretName: {{ .Values.connect.credentialsName }}
+            items:
+              - key: {{ .Values.connect.credentialsKey }}
+                path: 1password-credentials.json
         {{- if .Values.connect.tls.enabled }}
         - name: tls-cert
           secret:
@@ -60,10 +63,7 @@ spec:
             {{- toYaml .Values.connect.api.resources | nindent 12 }}
           env:
             - name: OP_SESSION
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.connect.credentialsName }}
-                  key: {{ .Values.connect.credentialsKey }}
+              value: /home/opuser/.op/1password-credentials.json
             - name: OP_BUS_PORT
               value: "11220"
             - name: OP_BUS_PEERS
@@ -100,6 +100,9 @@ spec:
           volumeMounts:
             - mountPath: /home/opuser/.op/data
               name: {{ .Values.connect.dataVolume.name }}
+            - name: credentials
+              mountPath: /home/opuser/.op/1password-credentials.json
+              subPath: 1password-credentials.json
             {{- if .Values.connect.tls.enabled }}
             - name: tls-cert
               mountPath: /home/opuser/.op/certs
@@ -117,10 +120,7 @@ spec:
             - name: OP_HTTP_PORT
               value: "{{ .Values.connect.sync.httpPort }}"
             - name: OP_SESSION
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.connect.credentialsName }}
-                  key: {{ .Values.connect.credentialsKey }}
+              value: /home/opuser/.op/1password-credentials.json
             - name: OP_BUS_PORT
               value: "11221"
             - name: OP_BUS_PEERS
@@ -145,3 +145,6 @@ spec:
           volumeMounts:
             - mountPath: /home/opuser/.op/data
               name: {{ .Values.connect.dataVolume.name }}
+            - name: credentials
+              mountPath: /home/opuser/.op/1password-credentials.json
+              subPath: 1password-credentials.json


### PR DESCRIPTION
Hi, thank you for your nice job!

I think I found a couple of minor issues. However, it could be I did not get the right way to use the chart :).

## Double encoded secret
The main repo creates the `connect-credentials` secret using the `stringData` method but provides binary strings:
https://github.com/1Password/connect-helm-charts/blob/a9e4e31a83356e9c9ad46cec93741dd89943676a/charts/connect/templates/connect-credentials.yaml#L14-L20
This ends up encoding the string twice making the mounted file not accessible by the software. Using the `data` method works as expected since the helm chart takes care of converting to binary when needed.

## `1password-credential.json` stored in an environmental variable
The main repo expects the server codes to use to read the credentials directly from the `OP_SESSION` variable. Thus the helm chart reads like this: 
https://github.com/1Password/connect-helm-charts/blob/a9e4e31a83356e9c9ad46cec93741dd89943676a/charts/connect/templates/connect-deployment.yaml#L61-L66
This stores the value of the secret in the `OP_SESSION` variable but the docs of the op-server are quite clear on the fact that [the variable only defines the path to the credential file](https://developer.1password.com/docs/connect/connect-server-configuration/). 

I fixed this issue by **creating a volume out of the credential-secret and mounting it always in the expected spot**. I don't see the need of allowing the users of the chart to define directly the `OP_SESSION`. In case, this can be easily modified though.  