### PR TITLE
feat: add deployment replicas to values

### DIFF
--- a/charts/connect/README.md
+++ b/charts/connect/README.md
@@ -46,6 +46,7 @@ $ helm install --set connect.applicationName=connect connect ./connect
 ### Values
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| connect.replicas | integer | `1` | The number of replicas to run the 1Password Connect deployment |
 | connect.applicationName | string | `"onepassword-connect"` | The name of 1Password Connect Application |
 | connect.api.imageRepository | string | `"1password/connect-api` | The 1Password Connect API repository |
 | connect.api.name | string | `"connect-api"` | The name of the 1Password Connect API container |

--- a/charts/connect/templates/connect-deployment.yaml
+++ b/charts/connect/templates/connect-deployment.yaml
@@ -35,6 +35,7 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
 {{- end }}
+      replicas: {{ .Values.connect.replicas }}
       volumes:
         - name: {{ .Values.connect.dataVolume.name }}
           {{ .Values.connect.dataVolume.type }}: {{- toYaml .Values.connect.dataVolume.values | nindent 12 }}

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -4,6 +4,9 @@
 
 # This section of values is for 1Password Connect API and Sync Configuration
 connect:
+  # The number of replicas to run the 1Password Connect deployment
+  replicas: 1
+
   # The 1Password Connect API Specific Values
   api:
     name: connect-api


### PR DESCRIPTION
Hi, I hope this PR is in line with the contributing guidelines, otherwise I'm happy to adjust it as you see fit. 😄 

This simple PR is here to enable user deployments to run with more replicas to have more stability and redundancy in case of any unexpected error like the running Pod getting evicted or something and there isn't another one available to fulfill the incoming requests making other applications fail to start. What do you think about it?