### PR TITLE
Moving replicas out of podspec

### DIFF
--- a/charts/connect/templates/connect-deployment.yaml
+++ b/charts/connect/templates/connect-deployment.yaml
@@ -14,6 +14,7 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  replicas: {{ .Values.connect.replicas }}
   selector:
     matchLabels:
       app: {{ .Values.connect.applicationName }}
@@ -34,8 +35,7 @@ spec:
 {{- with .Values.connect.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
-{{- end }}
-      replicas: {{ .Values.connect.replicas }}
+{{- end }}  
       volumes:
         - name: {{ .Values.connect.dataVolume.name }}
           {{ .Values.connect.dataVolume.type }}: {{- toYaml .Values.connect.dataVolume.values | nindent 12 }}

--- a/charts/connect/templates/scc.yaml
+++ b/charts/connect/templates/scc.yaml
@@ -1,0 +1,69 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: one-password-operator
+priority: 11
+readOnlyRootFilesystem: true
+requiredDropCapabilities:
+  - MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+users:
+  - system:serviceaccount:{{ $.Release.Namespace }}:{{ $.Values.connect.operator.serviceAccount.name }}
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: one-password
+priority: 11
+readOnlyRootFilesystem: true
+requiredDropCapabilities:
+  - MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+users:
+  - system:serviceaccount:{{ $.Release.Namespace }}:default


### PR DESCRIPTION
Fixes location of `replicas` per deployment spec.