### PR TITLE
Allow Connect server to be disabled in Helm chart deployment

### DIFF
--- a/charts/connect/README.md
+++ b/charts/connect/README.md
@@ -1,15 +1,17 @@
 # 1Password Connect
 
 ## Deploying 1Password Connect
+
 Installing the Helm Chart with default configurations will deploy 1Password Connect in your default Namespace. However, Using 1Password Connect in Kubernetes requires that a 1password-credentials.json file be stored as a Kubernetes Secret. This credentials file can be saved as a Kubernetes secret by setting the file in your helm install command:
 
 ```bash
 helm install connect 1password/connect --set-file connect.credentials=<path/to/1password-credentials.json>
 ```
 
-More information about 1Password Connect and how to generate a 1password-credentials.json file can be found at https://support.1password.com/secrets-automation/.
+More information about 1Password Connect and how to generate a 1password-credentials.json file can be found at <https://support.1password.com/secrets-automation/>.
 
 ## Deploying 1Password Connect Kubernetes Operator
+
 In order to deploy the 1Password Connect Kubernetes Operator along side 1Password Connect `--set operator.create=true` in your install command.
 
 Please note the following:
@@ -19,15 +21,16 @@ Creation of a secret for the token can be automated by the Helm Chart by using `
 
 If you would prefer to create the token secret manually, the token can be saved as a Kubernetes secret using the following command:
 
-```bash
-$ kubectl create secret generic <token-name> --from-literal=token=<OP_CONNECT_TOKEN> --namespace=<namespace>
+```sh
+kubectl create secret generic <token-name> --from-literal=token=<OP_CONNECT_TOKEN> --namespace=<namespace>
 ```
 
-More information about 1Password Connect and how to generate a 1Password Connect API token can be found at https://support.1password.com/secrets-automation/.
+More information about 1Password Connect and how to generate a 1Password Connect API token can be found at <https://support.1password.com/secrets-automation/>.
 
 To deploy the Kubernetes operator without also deploying 1Password Connect (for example, to deploy multiple operators on a single cluster), use `--set connect.create=false` in your install command.
 
 ## Configuration Values
+
 The 1Password Connect Helm chart offers many configuration options for deployment. Please refer to the list below for information on what configuration options are available as well as what the default configuration options are.
 
 [From the Official Helm Install Guide](https://helm.sh/docs/helm/helm_install/#helm-install):
@@ -35,17 +38,19 @@ The 1Password Connect Helm chart offers many configuration options for deploymen
 >To override values in a chart, use either the '--values' flag and pass in a file or use the '--set' flag and pass configuration from the command line, to force a string value use '--set-string'. In case a value is large and therefore you want not to use neither '--values' nor '--set', use '--set-file' to read the single large value from file.
 
 For example:
-```bash
-$ helm install -f myvalues.yaml connect ./connect
+
+```sh
+helm install -f myvalues.yaml connect ./connect
 ```
 
 or
 
-```bash
-$ helm install --set connect.applicationName=connect connect ./connect
+```sh
+helm install --set connect.applicationName=connect connect ./connect
 ```
 
 ### Values
+
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | connect.create | boolean | `true` | Denotes whether the 1Password Connect server will be deployed |

--- a/charts/connect/README.md
+++ b/charts/connect/README.md
@@ -25,6 +25,8 @@ $ kubectl create secret generic <token-name> --from-literal=token=<OP_CONNECT_TO
 
 More information about 1Password Connect and how to generate a 1Password Connect API token can be found at https://support.1password.com/secrets-automation/.
 
+To deploy the Kubernetes operator without also deploying 1Password Connect (for example, to deploy multiple operators on a single cluster), use `--set connect.create=false` in your install command.
+
 ## Configuration Values
 The 1Password Connect Helm chart offers many configuration options for deployment. Please refer to the list below for information on what configuration options are available as well as what the default configuration options are.
 
@@ -46,6 +48,7 @@ $ helm install --set connect.applicationName=connect connect ./connect
 ### Values
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| connect.create | boolean | `true` | Denotes whether the 1Password Connect server will be deployed |
 | connect.replicas | integer | `1` | The number of replicas to run the 1Password Connect deployment |
 | connect.applicationName | string | `"onepassword-connect"` | The name of 1Password Connect Application |
 | connect.api.imageRepository | string | `"1password/connect-api` | The 1Password Connect API repository |

--- a/charts/connect/templates/NOTES.txt
+++ b/charts/connect/templates/NOTES.txt
@@ -45,15 +45,27 @@
 ---------------------------------------------------------------------------------------------
 {{- end }}
 
+{{- if and (not (.Values.connect.create)) ( not (.Values.operator.create)) }}
+  {{- fail "The `connect.create` and `operator.create` are both set to `false`. At least one should be set to `true`." -}}
+{{- end -}}
+
 ** Please be patient while the chart is being deployed **
 
 1Password Connect is being deployed to Kubernetes. More information about 1Password Connect can 
 be found at https://support.1password.com/secrets-automation/
 
-{{- if  .Values.operator.create }}
+{{- if (.Values.connect.create) and (.Values.operator.create) }}
 
 The 1Password Connect Kubernetes Operator is also being deployed. More information about the 
 1Password Connect Operator can be found at https://github.com/1Password/onepassword-operator
 
 {{- end }}
 
+{{- if (not (.Values.connect.create)) and (.Values.operator.create) }}
+
+The 1Password Connect Kubernetes Operator is being deployed without also deploying a 1Password 
+Connect server. A Connect server is required for the operator to connect to. More information 
+about the 1Password Connect Operator can be found at 
+https://github.com/1Password/onepassword-operator
+
+{{- end }}

--- a/charts/connect/templates/connect-credentials.yaml
+++ b/charts/connect/templates/connect-credentials.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.connect.create}}
 {{- if or (.Values.connect.credentials) (.Values.connect.credentials_base64)  -}}
 {{- if and (.Values.connect.credentials) (.Values.connect.credentials_base64) -}}
   {{- fail "Only one of connect.credentials and connect.credentials_base64 can be specified" -}}
@@ -18,4 +19,5 @@ stringData:
   {{- else }}
   {{ .Values.connect.credentials_base64 | indent 2 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/connect/templates/connect-deployment.yaml
+++ b/charts/connect/templates/connect-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.connect.create }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -146,3 +147,4 @@ spec:
           volumeMounts:
             - mountPath: /home/opuser/.op/data
               name: {{ .Values.connect.dataVolume.name }}
+{{- end }}

--- a/charts/connect/templates/ingress.yaml
+++ b/charts/connect/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.connect.ingress.enabled -}}
+{{- if and (.Values.connect.ingress.enabled) (.Values.connect.create) -}} 
 {{- $extraPaths := .Values.connect.ingress.extraPaths -}}
 {{- $serviceName := .Values.connect.applicationName -}}
 {{- $tlsEnabled := .Values.connect.tls.enabled -}}

--- a/charts/connect/templates/service.yaml
+++ b/charts/connect/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.connect.create }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -29,3 +30,4 @@ spec:
   loadBalancerIP: {{.Values.connect.loadBalancerIP}}
   {{end}}
   {{end}}
+{{- end }}

--- a/charts/connect/templates/tests/health-check.yml
+++ b/charts/connect/templates/tests/health-check.yml
@@ -1,3 +1,4 @@
+{{- if .Values.connect.create }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -14,3 +15,4 @@ spec:
     - name: curl
       image: curlimages/curl
       command: ["curl", "{{- include "onepassword-connect.url" . }}/health"]
+{{- end }}

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -4,6 +4,9 @@
 
 # This section of values is for 1Password Connect API and Sync Configuration
 connect:
+  # Denotes whether the 1Password Connect server will be deployed
+  create: true
+
   # The number of replicas to run the 1Password Connect deployment
   replicas: 1
 


### PR DESCRIPTION
This PR introduces a `connect.create` value (defaulting to true) to allow Helm to deploy the Kubernetes operator without also deploying 1Password Connect (as discussed in #125).

Corresponding flow control is introduced throughout to disable other components not needed by the operator when it is being deployed standalone, a fail condition in case _both_ components are disabled, and an update to the `NOTES.txt` file for this configuration.

(I also did some housecleaning in the README based on my Markdown linter in a separate commit for clarity. 🧹)

This is a draft PR and has **not* yet been tested. 😅