### PR TITLE
Prepare release of connect-1.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# 1Password Connect Helm Charts
+# 1Password Helm Charts
 
-This repository hosts the offical 1Password Helm Charts for deploying 1Password Connect and the 1Password Connect Kubernetes Operator.
+This repository hosts the official 1Password Helm Charts.
 
 ## Installation Guide
 
@@ -17,4 +17,5 @@ helm repo add 1password https://1password.github.io/connect-helm-charts
 
 ## Available Charts
 
-* [1Password Connect and Kubernetes Operator](./charts/connect/)
+* [1Password Connect and Kubernetes Operator](./charts/connect)
+* [1Password Secrets Injector](./charts/secrets-injector)

--- a/charts/connect/CHANGELOG.md
+++ b/charts/connect/CHANGELOG.md
@@ -16,7 +16,7 @@
 # v1.10.0
 
 ## Features
-* Add replicas definition to the Connect Deployment {#121}
+* Add replicas definition to the Connect Deployment {#121, #128}
 * Use the latest 1password/operator version 1.6.0 {#128}
 
 ## Fixes

--- a/charts/connect/CHANGELOG.md
+++ b/charts/connect/CHANGELOG.md
@@ -13,6 +13,19 @@
 ---
 
 [//]: # (START/LATEST)
+# v1.10.0
+
+## Features
+* Add replicas definition to the Connect Deployment {#121}
+* Use the latest 1password/operator version 1.6.0 {#128}
+
+## Fixes
+* Move replicas definition to the top level spec section in the Connect Deployment {#128}
+* Use '1Password Operator' term instead of '1Password Connect Operator' in the documentation {#128}
+
+---
+
+[//]: # (START/LATEST)
 # v1.9.0
 
 ## Features

--- a/charts/connect/CHANGELOG.md
+++ b/charts/connect/CHANGELOG.md
@@ -20,7 +20,6 @@
 * Use the latest 1password/operator version 1.6.0 {#128}
 
 ## Fixes
-* Move replicas definition to the top level spec section in the Connect Deployment {#128}
 * Use '1Password Operator' term instead of '1Password Connect Operator' in the documentation {#128}
 
 ---

--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: connect
-version: 1.9.0
+version: 1.10.0
 description: A Helm chart for deploying 1Password Connect and the 1Password Connect Kubernetes Operator
 keywords:
   - "1Password"


### PR DESCRIPTION
## Features
* Add replicas definition to the Connect Deployment {#121, #128}
* Use the latest 1password/operator version 1.6.0 {#128}

## Fixes
* Use '1Password Operator' term instead of '1Password Connect Operator' in the documentation {#128}