### PR TITLE
feat: add replicas to operator deployment

### DIFF
--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
   - name: 1Password Secrets Integrations Team
     email: support+business@1password.com
 icon: https://avatars.githubusercontent.com/u/38230737
-appVersion: "1.5.7"
+appVersion: "1.6.0"

--- a/charts/connect/templates/operator-deployment.yaml
+++ b/charts/connect/templates/operator-deployment.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.operator.replicas }}
   selector:
     matchLabels:
       name: {{ .Values.connect.applicationName }}

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -152,6 +152,9 @@ operator:
   # Denotes whether the 1Password Operator will be deployed
   create: false
 
+  # The number of replicas to run the 1Password Operator deployment
+  replicas: 1
+
   # Denotes whether the 1Password Operator will automatically restart deployments based on associated updated secrets.
   autoRestart: false
 


### PR DESCRIPTION
Hi, this is a continuation from the work done at https://github.com/1Password/connect-helm-charts/pull/121 to allow multiple replicas for the operator deployment as well.

The rationale is the same to have redundancy in the deployment aiming for satefy/stability, what do you think?

I'm also fixing the appVersion in the Chart.yaml definition, given that the new chart default is operator version 1.6.0 and no longer 1.5.7