### PR TITLE
[DOCS] Add header to readme.md

### DIFF
--- a/charts/connect/README.md
+++ b/charts/connect/README.md
@@ -9,6 +9,8 @@ helm install connect 1password/connect --set-file connect.credentials=<path/to/1
 
 More information about 1Password Connect and how to generate a 1password-credentials.json file can be found at https://support.1password.com/secrets-automation/.
 
+# 1Password Connect Operator
+
 ## Deploying 1Password Connect Kubernetes Operator
 In order to deploy the 1Password Connect Kubernetes Operator along side 1Password Connect `--set operator.create=true` in your install command.
 


### PR DESCRIPTION
Add `1Password Connect Operator` header to README.md to make distinction between sections more obvious.