### PR TITLE
FEAT: Support imagePullSecrets in connect chart

### DIFF
--- a/charts/connect/templates/connect-deployment.yaml
+++ b/charts/connect/templates/connect-deployment.yaml
@@ -36,6 +36,10 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
 {{- end }}
+{{- with .Values.connect.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+{{- end }}
       volumes:
         - name: {{ .Values.connect.dataVolume.name }}
           {{ .Values.connect.dataVolume.type }}: {{- toYaml .Values.connect.dataVolume.values | nindent 12 }}

--- a/charts/connect/templates/operator-deployment.yaml
+++ b/charts/connect/templates/operator-deployment.yaml
@@ -36,6 +36,10 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
 {{- end }}
+{{- with .Values.operator.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+{{- end }}
       tolerations:
 {{ toYaml .Values.operator.tolerations | indent 8 }}
       serviceAccountName: {{ .Values.operator.serviceAccount.name }}

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -10,6 +10,7 @@ connect:
   # The secret use to pull from the container repository
   # imagePullSecrets:
   #   - name: my-private-repo
+
   # The 1Password Connect API Specific Values
   api:
     name: connect-api

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -7,6 +7,9 @@ connect:
   # The number of replicas to run the 1Password Connect deployment
   replicas: 1
 
+  # The secret use to pull from the container repository
+  # imagePullSecrets:
+  #   - name: my-private-repo
   # The 1Password Connect API Specific Values
   api:
     name: connect-api
@@ -163,6 +166,10 @@ operator:
 
   # The 1Password Operator repository
   imageRepository: 1password/onepassword-operator
+
+  # The secret use to pull from the container repository
+  # imagePullSecrets:
+  #   - name: my-private-repo
 
   # How often the 1Password Operator will poll for secrets updates.
   pollingInterval: 10


### PR DESCRIPTION
# Context
The helm chart support changing the container registry. However, it does not support `imagePullSecrets` which means that the images on our private registry must be public. 

# Proposal
Add this `imagePullSecrets` on the connect and operator deployment. By default, there is nothing but we can add this value if we want to use private registry. 
