### PR TITLE
Release connect-1.11.0

### DIFF
--- a/charts/connect/CHANGELOG.md
+++ b/charts/connect/CHANGELOG.md
@@ -12,7 +12,22 @@
 
 ---
 
-[//]: # (START/LATEST)
+[//]: # (START/v1.11.0)
+# v1.11.0
+
+## Features
+* Extra service annotations can now be specified with `connect.serviceAnnotations`. {#106}
+* `connect.create` can now be used to control whether a Connect instance should be created. {#125}
+* The default Connect version is updated to v1.7.0.
+
+## Fixes
+* The default value of `connect.CredentialsKey` is now correctly documented. {#136}
+
+Thanks @twink0r, @lapwat, @leehanel, @Matthiasvanderhallen for your contributions.
+
+---
+
+[//]: # (START/v1.10.0)
 # v1.10.0
 
 ## Features
@@ -24,7 +39,7 @@
 
 ---
 
-[//]: # (START/LATEST)
+[//]: # (START/v1.9.0)
 # v1.9.0
 
 ## Features

--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
   - name: 1Password Secrets Integrations Team
     email: support+business@1password.com
 icon: https://avatars.githubusercontent.com/u/38230737
-appVersion: "1.5.7"
+appVersion: "1.7.0"

--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: connect
-version: 1.10.0
+version: 1.11.0
 description: A Helm chart for deploying 1Password Connect and the 1Password Connect Kubernetes Operator
 keywords:
   - "1Password"


### PR DESCRIPTION
## Features
* Extra service annotations can now be specified with `connect.serviceAnnotations`. {#106}
* `connect.create` can now be used to control whether a Connect instance should be created. {#125}
* The default Connect version is updated to v1.7.0.

## Fixes
* The default value of `connect.CredentialsKey` is now correctly documented. {#136}

Thanks @twink0r, @lapwat, @leehanel, @Matthiasvanderhallen for your contributions.