### PR TITLE
Update operator default pollingInterval to 600 seconds

### DIFF
--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -171,7 +171,7 @@ operator:
   imageRepository: 1password/onepassword-operator
 
   # How often the 1Password Operator will poll for secrets updates.
-  pollingInterval: 10
+  pollingInterval: 600
 
   # The 1Password Operator version to pull
   version: "1.6.0"


### PR DESCRIPTION
This makes the default value consistent w/ the helm chart README, and the k8s operator README.