### PR TITLE
Prepare release secrets-injector-1.0.1

### DIFF
--- a/charts/secrets-injector/CHANGELOG.md
+++ b/charts/secrets-injector/CHANGELOG.md
@@ -12,6 +12,14 @@
 
 ---
 
+[//]: # (START/v1.0.1)
+# Latest
+
+## Fixes
+* Injector overrides Pod volumeMounts instead of appending to them. {#22}
+
+---
+
 [//]: # (START/v1.0.0)
 # v1.0.0
 

--- a/charts/secrets-injector/Chart.yaml
+++ b/charts/secrets-injector/Chart.yaml
@@ -11,5 +11,5 @@ maintainers:
   - name: 1Password Secrets Integrations Team
     email: support+business@1password.com
 icon: https://avatars.githubusercontent.com/u/38230737
-appVersion: "1.0.0"
-version: 1.0.0
+appVersion: "1.0.1"
+version: 1.0.1


### PR DESCRIPTION
Version 1.0.1 contains a pretty critical fix: https://github.com/1Password/kubernetes-secrets-injector/pull/24. It might be a good idea to make it the default and release a new version of the chart.

Closes #143