### PR TITLE
Improve the description of the connect.credentialsKey entry

### DIFF
--- a/charts/connect/README.md
+++ b/charts/connect/README.md
@@ -65,7 +65,7 @@ helm install --set connect.applicationName=connect connect ./connect
 | connect.api.httpsPort | integer | `8443` | The port the Connect API is served on when TLS is enabled |
 | connect.credentials | jsonString |  | Contents of the 1password-credentials.json file for Connect. Can be set be adding `--set-file connect.credentials=<path/to/1password-credentials.json>` to your helm install command |
 | connect.credentials_base64 | string |  | Base64-encoded contents of the 1password-credentials.json file for Connect. This can be used instead of `connect.credentials` in case supplying raw JSON to `connect.credentials` leads to issues.  |
-| connect.credentialsKey | string | `"1password-credentials.json"` | The key for the 1Password Connect Credentials stored in the credentials secret |
+| connect.credentialsKey | string | `"1password-credentials.json"` | The key for the 1Password Connect Credentials stored in the credentials secret, the credentials must be encoded as a base64 string |
 | connect.credentialsName | string | `"op-credentials"` | The name of Kubernetes Secret containing the 1Password Connect credentials |
 | connect.dataVolume.name | string | `"shared-data"` | The name of the shared volume used between 1Password Connect Containers |
 | connect.dataVolume.type | string | `"emptyDir"` | The type of the shared volume used between 1Password Connect Containers |


### PR DESCRIPTION
Warn about the usage of the base64 format to store the secret