### PR TITLE
Run 1Password/check-signed-commits-action for PRs

### DIFF
--- a/.github/workflows/pr-check-signed-commits.yml
+++ b/.github/workflows/pr-check-signed-commits.yml
@@ -1,0 +1,16 @@
+name: Check signed commits in PR 
+on: pull_request_target
+
+jobs:
+  build:
+    name: Check signed commits in PR 
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Check signed commits in PR
+        uses: 1Password/check-signed-commits-action@v1


### PR DESCRIPTION
The [check-signed-commits-action](https://github.com/1Password/check-signed-commits-action) action will leave a handy comment if a PR contains commits that are not signed.