### PR TITLE
Add option to enable profiler

### DIFF
--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
   - name: 1Password Secrets Integrations Team
     email: support+business@1password.com
 icon: https://avatars.githubusercontent.com/u/38230737
-appVersion: "1.7.0"
+appVersion: "1.7.1"

--- a/charts/connect/templates/_helpers.tpl
+++ b/charts/connect/templates/_helpers.tpl
@@ -102,3 +102,17 @@ Sets extra service annotations
     {{- end }}
   {{- end }}
 {{- end -}}
+
+{{/*
+Sets environment variables when profiler is enabled
+*/}}
+{{- define "onepassword-connect.profilerConfig" -}}
+  {{- if .Values.connect.profiler.enabled}}
+- name: OP_PROFILER_OUTPUT_DIR
+  value: "/home/opuser/.op/data/profiler"
+- name: OP_PROFILER_INTERVAL
+  value: "{{ .Values.connect.profiler.interval }}"
+- name: OP_PROFILER_KEEP_LAST
+  value: "{{ .Values.connect.profiler.keepLast }}"
+  {{- end -}}
+{{- end -}}

--- a/charts/connect/templates/connect-deployment.yaml
+++ b/charts/connect/templates/connect-deployment.yaml
@@ -83,6 +83,7 @@ spec:
             {{- end }}
             - name: OP_LOG_LEVEL
               value: "{{ .Values.connect.api.logLevel }}"
+            {{- include "onepassword-connect.profilerConfig" . | indent 12 -}}
           {{- if .Values.connect.probes.readiness }}
           readinessProbe:
             httpGet:
@@ -131,6 +132,7 @@ spec:
               value: localhost:11220
             - name: OP_LOG_LEVEL
               value: "{{ .Values.connect.sync.logLevel }}"
+            {{- include "onepassword-connect.profilerConfig" . | indent 12 }}
           {{- if .Values.connect.probes.readiness }}
           readinessProbe:
             httpGet:
@@ -151,4 +153,13 @@ spec:
           volumeMounts:
             - mountPath: /home/opuser/.op/data
               name: {{ .Values.connect.dataVolume.name }}
+        {{- if .Values.connect.profiler.enabled }}
+        - name: profiler-data
+          image: alpine
+          command: [ 'sleep', 'infinity' ]
+          volumeMounts:
+            - name: {{ .Values.connect.dataVolume.name }}
+              mountPath: /data
+              subPath: profiler
+        {{- end }}
 {{- end }}

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -155,6 +155,15 @@ connect:
     #    hosts:
     #      - chart-example.local
 
+  # Optionally the internal profiler can be enabled to debug memory or performance issues.
+  # For normal operation of Connect this does not have to enabled.
+  profiler:
+    enabled: false
+    # The interval at which profiler snapshots are taken.
+    interval: 6h
+    # Number of profiler snapshots to keep.
+    keepLast: 12
+
 # This section of values is for 1Password Operator Configuration
 operator:
   # Denotes whether the 1Password Operator will be deployed


### PR DESCRIPTION
This will help us debug some of the reported memory leaks.

An extra container is added if the profiler is enabled to allow copying the profiler data out of the pod. This is needed because the Connect images are distroless and therefore do not support `kubectl cp`.

If enabled, data can be exported by running:
```
kubectl cp -c profiler-data <pod>:/data profiler
```