### PR TITLE
Prepare release connect-1.12.0

### DIFF
--- a/charts/connect/CHANGELOG.md
+++ b/charts/connect/CHANGELOG.md
@@ -13,6 +13,23 @@
 ---
 
 [//]: # (START/v1.11.0)
+# v1.12.0
+
+## Features
+* Connect's log level can now be specified using connect.api.loglevel and connect.sync.logLevel. {#135}
+* The default Connect version is updated to v1.7.1.
+* Connect's profiler can now be enabled through the Helm chart to help 1Password debug memory and performance issues. {#157} 
+
+## Fixes
+* Ingress now correctly works if TLS is enabled. {#140}
+* The operators's polling interval is now consistent with the readme's. {#147}
+* The readme now correctly mentions the Connect's credential file must be base64-encoded. {#155}
+
+Thanks @antham, @akohlmann, @Altiire, @JoshCooley-alto for your contributions.
+
+---
+
+[//]: # (START/v1.11.0)
 # v1.11.0
 
 ## Features

--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: connect
-version: 1.11.0
+version: 1.12.0
 description: A Helm chart for deploying 1Password Connect and the 1Password Connect Kubernetes Operator
 keywords:
   - "1Password"


### PR DESCRIPTION
## Features
* Connect's log level can now be specified using connect.api.loglevel and connect.sync.logLevel. {#135}
* The default Connect version is updated to v1.7.1.
* Connect's profiler can now be enabled through the Helm chart to help 1Password debug memory and performance issues. {#157} 

## Fixes
* Ingress now correctly works if TLS is enabled. {#140}
* The operators's polling interval is now consistent with the readme's. {#147}
* The readme now correctly mentions the Connect's credential file must be base64-encoded. {#155}

Thanks @antham, @akohlmann, @Altiire, @JoshCooley-alto for your contributions.