### PR TITLE
Expose connect.host to be able to override Connect host

### DIFF
--- a/charts/connect/README.md
+++ b/charts/connect/README.md
@@ -53,77 +53,78 @@ helm install --set connect.applicationName=connect connect ./connect
 
 ### Values
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| connect.create | boolean | `true` | Denotes whether the 1Password Connect server will be deployed |
-| connect.replicas | integer | `1` | The number of replicas to run the 1Password Connect deployment |
-| connect.applicationName | string | `"onepassword-connect"` | The name of 1Password Connect Application |
-| connect.api.imageRepository | string | `"1password/connect-api` | The 1Password Connect API repository |
-| connect.api.name | string | `"connect-api"` | The name of the 1Password Connect API container |
-| connect.api.resources | object | `{}` | The resources requests/limits for the 1Password Connect API pod |
-| connect.api.httpPort | integer | `8080` | The port the Connect API is served on when TLS is disabled |
-| connect.api.httpsPort | integer | `8443` | The port the Connect API is served on when TLS is enabled |
-| connect.api.logLevel | string | `info` | Log level of the Connect API container. Valid options are: trace, debug, info, warn, error. |
-| connect.credentials | jsonString |  | Contents of the 1password-credentials.json file for Connect. Can be set be adding `--set-file connect.credentials=<path/to/1password-credentials.json>` to your helm install command |
-| connect.credentials_base64 | string |  | Base64-encoded contents of the 1password-credentials.json file for Connect. This can be used instead of `connect.credentials` in case supplying raw JSON to `connect.credentials` leads to issues.  |
-| connect.credentialsKey | string | `"1password-credentials.json"` | The key for the 1Password Connect Credentials stored in the credentials secret, the credentials must be encoded as a base64 string |
-| connect.credentialsName | string | `"op-credentials"` | The name of Kubernetes Secret containing the 1Password Connect credentials |
-| connect.dataVolume.name | string | `"shared-data"` | The name of the shared volume used between 1Password Connect Containers |
-| connect.dataVolume.type | string | `"emptyDir"` | The type of the shared volume used between 1Password Connect Containers |
-| connect.dataVolume.values | object | `{}` | Desribes the fields and values for configuration of shared volume for 1Password Connect |
-| connect.imagePullPolicy | string | `"IfNotPresent"` | The 1Password Connect API image pull policy |
-| connect.ingress.annotations | object | `{}` | The 1Password Connect Ingress Annotations |
-| connect.ingress.enabled | bool | `false` | The boolean value to enable/disable the 1Password Connect |
-| connect.ingress.extraPaths | list | `[]` | Additional Ingress Paths |
-| connect.ingress.hosts[0].host | string | `"chart-example.local"` | The 1Password Connect Ingress Hostname |
-| connect.ingress.hosts[0].paths | list | `[]` | The 1Password Connect Ingress Path |
-| connect.ingress.ingressClassName | string | `""` | Optionally use ingressClassName instead of deprecated annotation. |
-| connect.ingress.labels | object | `{}` | Ingress labels for 1Password Connect |
-| connect.ingress.pathType | string | `"Prefix"` | Ingress PathType see [docs](https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types) |
-| connect.ingress.tls | list | `[]` | Ingress TLS see [docs](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) |
-| connect.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) stanza for the Connect pod |
-| connect.probes.readiness | boolean | `true` | Denotes whether the 1Password Connect API readiness probe will operate and ensure the pod is ready before serving traffic |
-| connect.probes.liveness | boolean | `true` | Denotes whether the 1Password Connect API will be continually checked by Kubernetes for liveness and restarted if the pod becomes unresponsive |
-| connect.annotations | object | `{}` | Additional annotations to be added to the Connect API deployment resource. |
-| connect.labels | object | `{}` | Additional labels to be added to the Connect API deployment resource. |
-| connect.podAnnotations | object | `{}` | Additional annotations to be added to the Connect API pods. |
-| connect.podLabels | object | `{}` | Additional labels to be added to the Connect API pods.  |
-| connect.serviceType | string | `NodePort` | The type of Service resource to create for the Connect API and sync services. |
-| connect.serviceAnnotations | object | `{}` | Additional annotations to be added to the service. |
-| connect.sync.imageRepository | string | `"1password/connect-sync"` | The 1Password Connect Sync repository |
-| connect.sync.name | string | `"connect-sync"` | The name of the 1Password Connect Sync container |
-| connect.sync.resources | object | `{}` | The resources requests/limits for the 1Password Connect Sync pod |
-| connect.sync.httpPort | integer | `8081` | The port serving the health of the Sync container |
-| connect.sync.logLevel | string | `info` | Log level of the Connect Sync container. Valid options are: trace, debug, info, warn, error. |
-| connect.tls.enabled | boolean | `false` | Denotes whether the Connect API is secured with TLS |
-| connect.tls.secret | string | `"op-connect-tls"` | The name of the secret containing the TLS key (`tls.key`) and certificate (`tls.crt`)  |
-| connect.tolerations | list | `[]` | List of tolerations to be added to the Connect API pods.  |
-| connect.version | string | `{{.Chart.AppVersion}}` | The 1Password Connect version to pull |
-| operator.autoRestart | boolean | `false` | Denotes whether the 1Password Operator will automatically restart deployments based on associated updated secrets. |
-| operator.create | boolean | `false` | Denotes whether the 1Password Operator will be deployed |
-| operator.imagePullPolicy | string | `"IfNotPresent"` | The 1Password Operator image pull policy |
-| operator.imageRepository | string | `"1password/onepassword-operator"` | The 1Password Operator repository |
-| operator.nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) stanza for the operator pod |
-| operator.annotations | object | `{}` | Additional annotations to be added to the Operator deployment resource. |
-| operator.labels | object | `{}` | Additional labels to be added to the Operator deployment resource. |
-| operator.podAnnotations | object | `{}` | Additional annotations to be added to the Operator pods. |
-| operator.podLabels | object | `{}` | Additional labels to be added to the Operator pods.  |
-| operator.pollingInterval | integer | `600` | How often the 1Password Operator will poll for secrets updates. |
-| operator.clusterRole.create | boolean | `{{.Values.operator.create}}` | Denotes whether or not a cluster role will be created for each for the 1Password Operator |
-| operator.clusterRole.name | string | `"onepassword-connect-operator"` | The name of the 1Password Operator Cluster Role |
-| operator.clusterRoleBinding.create | boolean | `{{.Values.operator.create}}` | Denotes whether or not a Cluster role binding will be created for the 1Password Operator Service Account |
-| operator.roleBinding.create | boolean | `{{.Values.operator.create}}` | Denotes whether or not a role binding will be created for each Namespace for the 1Password Operator Service Account |
-| operator.roleBinding.name | string | `"onepassword-connect-operator"` | The name of the 1Password Operator Role Binding |
-| operator.serviceAccount.annotations | object | `{}` | Annotations for the 1Password Connect Service Account |
-| operator.serviceAccount.create | boolean | `{{.Values.operator.create}}` | Denotes whether or not a service account will be created for the 1Password Operator |
-| operator.serviceAccount.name | string | `"onepassword-connect-operator"` | The name of the 1Password Conenct Operator |
-| operator.tolerations | list | `[]` | List of tolerations to be added to the Operator pods.  |
-| operator.version | string | `"1.6.0"` | T 1Password Operator version to pull |
-| operator.token.key | string | `"token"` | The key for the 1Password Connect token stored in the 1Password token secret |
-| operator.token.name | string | `"onepassword-token"` | The name of Kubernetes Secret containing the 1Password Connect API token |
-| operator.token.value | string | `"onepassword-token"` | An API token generated for 1Password Connect to be used by the Connect Operator |
-| operator.watchNamespace | list | `[]` | A list of namespaces for the 1Password Operator to watch and manage. Use the empty list to watch all namespaces. |
-| operator.resources | object | `{}` | The resources requests/limits for the 1Password Operator pod |
+| Key                                 | Type | Default | Description                                                                                                                                                                                        |
+|-------------------------------------|------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| connect.create                      | boolean | `true` | Denotes whether the 1Password Connect server will be deployed                                                                                                                                      |
+| connect.replicas                    | integer | `1` | The number of replicas to run the 1Password Connect deployment                                                                                                                                     |
+| connect.applicationName             | string | `"onepassword-connect"` | The name of 1Password Connect Application                                                                                                                                                          |
+| connect.host                        | string | `"onepassword-connect"` | The name of 1Password Connect Host                                                                                                                                                                 |
+| connect.api.imageRepository         | string | `"1password/connect-api` | The 1Password Connect API repository                                                                                                                                                               |
+| connect.api.name                    | string | `"connect-api"` | The name of the 1Password Connect API container                                                                                                                                                    |
+| connect.api.resources               | object | `{}` | The resources requests/limits for the 1Password Connect API pod                                                                                                                                    |
+| connect.api.httpPort                | integer | `8080` | The port the Connect API is served on when TLS is disabled                                                                                                                                         |
+| connect.api.httpsPort               | integer | `8443` | The port the Connect API is served on when TLS is enabled                                                                                                                                          |
+| connect.api.logLevel                | string | `info` | Log level of the Connect API container. Valid options are: trace, debug, info, warn, error.                                                                                                        |
+| connect.credentials                 | jsonString |  | Contents of the 1password-credentials.json file for Connect. Can be set be adding `--set-file connect.credentials=<path/to/1password-credentials.json>` to your helm install command               |
+| connect.credentials_base64          | string |  | Base64-encoded contents of the 1password-credentials.json file for Connect. This can be used instead of `connect.credentials` in case supplying raw JSON to `connect.credentials` leads to issues. |
+| connect.credentialsKey              | string | `"1password-credentials.json"` | The key for the 1Password Connect Credentials stored in the credentials secret, the credentials must be encoded as a base64 string                                                                 |
+| connect.credentialsName             | string | `"op-credentials"` | The name of Kubernetes Secret containing the 1Password Connect credentials                                                                                                                         |
+| connect.dataVolume.name             | string | `"shared-data"` | The name of the shared volume used between 1Password Connect Containers                                                                                                                            |
+| connect.dataVolume.type             | string | `"emptyDir"` | The type of the shared volume used between 1Password Connect Containers                                                                                                                            |
+| connect.dataVolume.values           | object | `{}` | Desribes the fields and values for configuration of shared volume for 1Password Connect                                                                                                            |
+| connect.imagePullPolicy             | string | `"IfNotPresent"` | The 1Password Connect API image pull policy                                                                                                                                                        |
+| connect.ingress.annotations         | object | `{}` | The 1Password Connect Ingress Annotations                                                                                                                                                          |
+| connect.ingress.enabled             | bool | `false` | The boolean value to enable/disable the 1Password Connect                                                                                                                                          |
+| connect.ingress.extraPaths          | list | `[]` | Additional Ingress Paths                                                                                                                                                                           |
+| connect.ingress.hosts[0].host       | string | `"chart-example.local"` | The 1Password Connect Ingress Hostname                                                                                                                                                             |
+| connect.ingress.hosts[0].paths      | list | `[]` | The 1Password Connect Ingress Path                                                                                                                                                                 |
+| connect.ingress.ingressClassName    | string | `""` | Optionally use ingressClassName instead of deprecated annotation.                                                                                                                                  |
+| connect.ingress.labels              | object | `{}` | Ingress labels for 1Password Connect                                                                                                                                                               |
+| connect.ingress.pathType            | string | `"Prefix"` | Ingress PathType see [docs](https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types)                                                                                           |
+| connect.ingress.tls                 | list | `[]` | Ingress TLS see [docs](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls)                                                                                                       |
+| connect.nodeSelector                | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) stanza for the Connect pod                                                                  |
+| connect.probes.readiness            | boolean | `true` | Denotes whether the 1Password Connect API readiness probe will operate and ensure the pod is ready before serving traffic                                                                          |
+| connect.probes.liveness             | boolean | `true` | Denotes whether the 1Password Connect API will be continually checked by Kubernetes for liveness and restarted if the pod becomes unresponsive                                                     |
+| connect.annotations                 | object | `{}` | Additional annotations to be added to the Connect API deployment resource.                                                                                                                         |
+| connect.labels                      | object | `{}` | Additional labels to be added to the Connect API deployment resource.                                                                                                                              |
+| connect.podAnnotations              | object | `{}` | Additional annotations to be added to the Connect API pods.                                                                                                                                        |
+| connect.podLabels                   | object | `{}` | Additional labels to be added to the Connect API pods.                                                                                                                                             |
+| connect.serviceType                 | string | `NodePort` | The type of Service resource to create for the Connect API and sync services.                                                                                                                      |
+| connect.serviceAnnotations          | object | `{}` | Additional annotations to be added to the service.                                                                                                                                                 |
+| connect.sync.imageRepository        | string | `"1password/connect-sync"` | The 1Password Connect Sync repository                                                                                                                                                              |
+| connect.sync.name                   | string | `"connect-sync"` | The name of the 1Password Connect Sync container                                                                                                                                                   |
+| connect.sync.resources              | object | `{}` | The resources requests/limits for the 1Password Connect Sync pod                                                                                                                                   |
+| connect.sync.httpPort               | integer | `8081` | The port serving the health of the Sync container                                                                                                                                                  |
+| connect.sync.logLevel               | string | `info` | Log level of the Connect Sync container. Valid options are: trace, debug, info, warn, error.                                                                                                       |
+| connect.tls.enabled                 | boolean | `false` | Denotes whether the Connect API is secured with TLS                                                                                                                                                |
+| connect.tls.secret                  | string | `"op-connect-tls"` | The name of the secret containing the TLS key (`tls.key`) and certificate (`tls.crt`)                                                                                                              |
+| connect.tolerations                 | list | `[]` | List of tolerations to be added to the Connect API pods.                                                                                                                                           |
+| connect.version                     | string | `{{.Chart.AppVersion}}` | The 1Password Connect version to pull                                                                                                                                                              |
+| operator.autoRestart                | boolean | `false` | Denotes whether the 1Password Operator will automatically restart deployments based on associated updated secrets.                                                                                 |
+| operator.create                     | boolean | `false` | Denotes whether the 1Password Operator will be deployed                                                                                                                                            |
+| operator.imagePullPolicy            | string | `"IfNotPresent"` | The 1Password Operator image pull policy                                                                                                                                                           |
+| operator.imageRepository            | string | `"1password/onepassword-operator"` | The 1Password Operator repository                                                                                                                                                                  |
+| operator.nodeSelector               | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) stanza for the operator pod                                                                 |
+| operator.annotations                | object | `{}` | Additional annotations to be added to the Operator deployment resource.                                                                                                                            |
+| operator.labels                     | object | `{}` | Additional labels to be added to the Operator deployment resource.                                                                                                                                 |
+| operator.podAnnotations             | object | `{}` | Additional annotations to be added to the Operator pods.                                                                                                                                           |
+| operator.podLabels                  | object | `{}` | Additional labels to be added to the Operator pods.                                                                                                                                                |
+| operator.pollingInterval            | integer | `600` | How often the 1Password Operator will poll for secrets updates.                                                                                                                                    |
+| operator.clusterRole.create         | boolean | `{{.Values.operator.create}}` | Denotes whether or not a cluster role will be created for each for the 1Password Operator                                                                                                          |
+| operator.clusterRole.name           | string | `"onepassword-connect-operator"` | The name of the 1Password Operator Cluster Role                                                                                                                                                    |
+| operator.clusterRoleBinding.create  | boolean | `{{.Values.operator.create}}` | Denotes whether or not a Cluster role binding will be created for the 1Password Operator Service Account                                                                                           |
+| operator.roleBinding.create         | boolean | `{{.Values.operator.create}}` | Denotes whether or not a role binding will be created for each Namespace for the 1Password Operator Service Account                                                                                |
+| operator.roleBinding.name           | string | `"onepassword-connect-operator"` | The name of the 1Password Operator Role Binding                                                                                                                                                    |
+| operator.serviceAccount.annotations | object | `{}` | Annotations for the 1Password Connect Service Account                                                                                                                                              |
+| operator.serviceAccount.create      | boolean | `{{.Values.operator.create}}` | Denotes whether or not a service account will be created for the 1Password Operator                                                                                                                |
+| operator.serviceAccount.name        | string | `"onepassword-connect-operator"` | The name of the 1Password Conenct Operator                                                                                                                                                         |
+| operator.tolerations                | list | `[]` | List of tolerations to be added to the Operator pods.                                                                                                                                              |
+| operator.version                    | string | `"1.6.0"` | T 1Password Operator version to pull                                                                                                                                                               |
+| operator.token.key                  | string | `"token"` | The key for the 1Password Connect token stored in the 1Password token secret                                                                                                                       |
+| operator.token.name                 | string | `"onepassword-token"` | The name of Kubernetes Secret containing the 1Password Connect API token                                                                                                                           |
+| operator.token.value                | string | `"onepassword-token"` | An API token generated for 1Password Connect to be used by the Connect Operator                                                                                                                    |
+| operator.watchNamespace             | list | `[]` | A list of namespaces for the 1Password Operator to watch and manage. Use the empty list to watch all namespaces.                                                                                   |
+| operator.resources                  | object | `{}` | The resources requests/limits for the 1Password Operator pod                                                                                                                                       |
 
 ### CRD
 

--- a/charts/connect/templates/_helpers.tpl
+++ b/charts/connect/templates/_helpers.tpl
@@ -49,9 +49,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{- define "onepassword-connect.url" -}}
 {{- if .Values.connect.tls.enabled -}}
-https://{{ .Values.connect.applicationName }}:{{ .Values.connect.api.httpsPort  }}
+https://{{ .Values.connect.host }}:{{ .Values.connect.api.httpsPort  }}
 {{- else -}}
-http://{{ .Values.connect.applicationName }}:{{ .Values.connect.api.httpPort  }}
+http://{{ .Values.connect.host }}:{{ .Values.connect.api.httpPort  }}
 {{- end }}
 {{- end }}
 

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -31,6 +31,9 @@ connect:
   # The name of 1Password Connect Application
   applicationName: onepassword-connect
 
+  # The name of 1Password Connect Host
+  host: onepassword-connect
+
   # The type of Service resource to create for the Connect API and sync services.
   # See: https://kubernetes.io/docs/concepts/services-networking/service
   # This by default is NodePort and can also be defined as LoadBalancer.


### PR DESCRIPTION
Resolves #148 

This PR provides an ability to use Connect deployed in the other namespace than the operator. Therefore, it also gives the ability to use a single Connect instance with multiple operators.


Instructions below demonstrate how to set up a **single Connect instance** in the `default` namespace and **2 operator instances**, one in `test1` namespace and the second in `test2` namespace. Each of the operators watches for its own namespace (aka `operator1` watches for namespace `test1` and `operator2` watches for namespace `test2`). Also, each operator uses a different Connect token saved in the Secret (`onepassword-token1` and `onepassword-token2`).


### Deploy Connect to the `default` namespace
`helm install connect 1password/connect --set-file connect.credentials=1password-credentials.json -n default`

### Prepare namespace `test1` and deploy Operator

- Create `test1` namesapce `kubectl create namespace test1`
- Create Secret containing Connect token `kubectl create secret generic onepassword-token1 --from-literal=token="<YOUR_CONNECT_TOKEN>" -n test1`
- Deploy Operator
```
helm install opearator1 1password/connect --set connect.create=false --set connect.host=onepassword-connect.default.svc.cluster.local --set operator.create=true --set operator.watchNamespace={test1} --set operator.token.name=onepassword-token1 --set operator.serviceAccount.name=onepassword-connect-operator1 --set operator.clusterRole.name=onepassword-connect-operator1 --set operator.applicationName=onepassword-connect-operator1 -n test1
```
**Note**: in you need to override `clusterRole`, `applicationName`, `serviceAccount` to be unique in order to be able to deploy other Operator instances. Also, pay attention to using the propper `operator.token.name=onepassword-token1` and properly specify the namespace you want the Operator to watch for `operator.watchNamespace={test1}`. If no `operator.watchNamespace` is specified it watches for **ALL** namespaces. In order for the Operator to use Connect deployed in the `default` namespace override Connect host by setting `connect.host=onepassword-connect.default.svc.cluster.local`.

### Prepare namespace `test2` and deploy Operator

- Create `test1` namesapce `kubectl create namespace test2`
- Create Secret containing Connect token `kubectl create secret generic onepassword-token2 --from-literal=token="<YOUR_CONNECT_TOKEN>" -n test2`
- Deploy Operator
```
helm install opearator2 1password/connect --set connect.create=false --set connect.host=onepassword-connect.default.svc.cluster.local --set operator.create=true --set operator.watchNamespace={test2} --set operator.token.name=onepassword-token2 --set operator.serviceAccount.name=onepassword-connect-operator2 --set operator.clusterRole.name=onepassword-connect-operator2 --set operator.applicationName=onepassword-connect-operator2 -n test2
```
**Note**: in you need to override `clusterRole`, `applicationName`, `serviceAccount` to be unique in order to be able to deploy other Operator instances. Also, pay attention to using the propper `operator.token.name=onepassword-token2` and properly specify the namespace you want the Operator to watch for `operator.watchNamespace={test2}`. If no `operator.watchNamespace` is specified it watches for **ALL** namespaces. In order for the Operator to use Connect deployed in the `default` namespace override Connect host by setting `connect.host=onepassword-connect.default.svc.cluster.local`.


### Create OnepasswordItems

- Use the snippet below to create OnepasswordItems (replace `itemPath` with valid one)
```
# test-cred.yaml
apiVersion: onepassword.com/v1
kind: OnePasswordItem
metadata:
  name: test-creds
spec:
  itemPath: "vaults/vauld_id/items/item_id"
```
- Create OnepasswordItem in `test1` namespace `kubectl apply -f test-cred.yaml -n test1`
- Check that `test-cred` Secret is created `kubectl get secret test-creds -n test1`
- Create OnepasswordItem in `test2` namespace `kubectl apply -f test-cred.yaml -n test2`
- Check that `test-cred` Secret is created `kubectl get secret test-creds -n test2`


**Note**: the same scenario will work if deploy all the Operators in the single namespace aka `operators`