### PR TITLE
Prepare release connect-1.12.1

### DIFF
--- a/charts/connect/CHANGELOG.md
+++ b/charts/connect/CHANGELOG.md
@@ -12,7 +12,15 @@
 
 ---
 
-[//]: # (START/v1.11.0)
+[//]: # (START/v1.12.1)
+# v1.12.1
+
+## Fixes
+* Distinct standalone operator Helm deployments use the same lock. {#148}
+
+---
+
+[//]: # (START/v1.12.0)
 # v1.12.0
 
 ## Features

--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: connect
-version: 1.12.0
+version: 1.12.1
 description: A Helm chart for deploying 1Password Connect and the 1Password Connect Kubernetes Operator
 keywords:
   - "1Password"


### PR DESCRIPTION
# v1.12.1

## Fixes
* Distinct standalone operator Helm deployments use the same lock. {#148}