### PR TITLE
Preparing release connect-1.13.0

### DIFF
--- a/charts/connect/CHANGELOG.md
+++ b/charts/connect/CHANGELOG.md
@@ -12,6 +12,15 @@
 
 ---
 
+[//]: # (START/v1.12.2)
+# v1.12.1
+
+## Fixes
+* Upgraded to default to version 1.7.1 of the Operator. {#164}
+* The Connect helm char now supports the ability to set the logging level on the Operator. {#164}
+
+---
+
 [//]: # (START/v1.12.1)
 # v1.12.1
 

--- a/charts/connect/CHANGELOG.md
+++ b/charts/connect/CHANGELOG.md
@@ -13,7 +13,7 @@
 ---
 
 [//]: # (START/v1.12.2)
-# v1.12.1
+# v1.12.2
 
 ## Fixes
 * Upgraded to default to version 1.7.1 of the Operator. {#164}

--- a/charts/connect/CHANGELOG.md
+++ b/charts/connect/CHANGELOG.md
@@ -12,10 +12,10 @@
 
 ---
 
-[//]: # (START/v1.12.2)
-# v1.12.2
+[//]: # (START/v1.13.0)
+# v1.13.0
 
-## Fixes
+## Features
 * Upgraded to default to version 1.7.1 of the Operator. {#164}
 * The Connect helm char now supports the ability to set the logging level on the Operator. {#164}
 

--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: connect
-version: 1.12.1
+version: 1.12.2
 description: A Helm chart for deploying 1Password Connect and the 1Password Connect Kubernetes Operator
 keywords:
   - "1Password"

--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: connect
-version: 1.12.2
+version: 1.13.0
 description: A Helm chart for deploying 1Password Connect and the 1Password Connect Kubernetes Operator
 keywords:
   - "1Password"


### PR DESCRIPTION
This release includes the following:
* Upgraded to default to version 1.7.1 of the Operator. {#164}
* The Connect helm char now supports the ability to set the logging level on the Operator. {#164}