### PR TITLE
connect-chart v1.13.1 release

### DIFF
--- a/charts/connect/CHANGELOG.md
+++ b/charts/connect/CHANGELOG.md
@@ -12,6 +12,15 @@
 
 ---
 
+[//]: # (START/v1.13.1)
+# v1.13.1
+
+## Features
+* The default Operator version is updated to v1.8.0 {#168}
+* The default Connect version is updated to v1.7.2.
+
+---
+
 [//]: # (START/v1.13.0)
 # v1.13.0
 

--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
   - name: 1Password Secrets Integrations Team
     email: support+business@1password.com
 icon: https://avatars.githubusercontent.com/u/38230737
-appVersion: "1.7.1"
+appVersion: "1.7.2"

--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: connect
-version: 1.13.0
+version: 1.13.1
 description: A Helm chart for deploying 1Password Connect and the 1Password Connect Kubernetes Operator
 keywords:
   - "1Password"


### PR DESCRIPTION
This release includes the following:

* The default Operator version is updated to v1.8.0 {#168}
* The default Connect version is updated to v1.7.2.