### PR TITLE
add labels and selectors for Pod to Node assignment

### DIFF
--- a/charts/secrets-injector/templates/deployment.yaml
+++ b/charts/secrets-injector/templates/deployment.yaml
@@ -5,9 +5,16 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Values.injector.applicationName }}
+    {{- include "onepassword-connect.labels" . | nindent 4 }}
+  {{- with .Values.connect.labels }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.connect.annotations }}
   annotations:
     helm.sh/hook: pre-install
     helm.sh/hook-weight: "1"
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -16,7 +23,20 @@ spec:
     metadata:
       labels:
         app: {{ .Values.injector.applicationName }}
+      {{- with .Values.connect.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.connect.podAnnotations }}
+      annotations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
+{{- with .Values.connect.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+      tolerations:
+{{ toYaml .Values.connect.tolerations | indent 8 }}
       serviceAccountName: {{ .Values.injector.applicationName }}
       containers:
         - name: {{ .Values.injector.applicationName }}

--- a/charts/secrets-injector/values.yaml
+++ b/charts/secrets-injector/values.yaml
@@ -5,3 +5,22 @@ injector:
   port: 443
   targetPort: 8443
   version: "{{ .Chart.AppVersion }}"
+  # Node selector stanza for the Secrets Injector pod
+  # See: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+  nodeSelector: {}
+
+  # Additional annotations to be added to the Secrets Injector deployment resource.
+  annotations: {}
+
+  # Additional labels to be added to the Secrets Injector deployment resource.
+  labels: {}
+  
+  # Additional annotations to be added to the Secrets Injector pod.
+  podAnnotations: {}
+  
+  # Additional labels to be added to the Secrets Injector pod.
+  podLabels: {}
+  
+  # List of tolerations to be added to the Secrets Injector pod.
+  tolerations: []
+  


### PR DESCRIPTION
added the following to Secrets-Injector deployment:
nodeSelector
annotations
labels
podAnnotations
podLabels
tolerations   
