### PR TITLE
remove hook annotations from deployment

### DIFF
--- a/charts/secrets-injector/templates/deployment.yaml
+++ b/charts/secrets-injector/templates/deployment.yaml
@@ -5,9 +5,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Values.injector.applicationName }}
-  annotations:
-    helm.sh/hook: pre-install
-    helm.sh/hook-weight: "1"
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
there doesn't appear to be any reason for these, and until [post-rendering support is added for hooks](https://github.com/helm/helm/pull/12775), having these makes it difficult to patch with annotations such as those required for services meshes or other policy enforcement mechanisms.