### PR TITLE
Fix 1password-credentials secret injection

### DIFF
--- a/charts/connect/templates/connect-credentials.yaml
+++ b/charts/connect/templates/connect-credentials.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/component: connect
     {{- include "onepassword-connect.labels" . | nindent 4 }}
 type: Opaque
-stringData:
+data:
   {{ .Values.connect.credentialsKey }}: |-
   {{- if (.Values.connect.credentials) }}
   {{ .Values.connect.credentials | b64enc | indent 2 }}

--- a/charts/connect/templates/connect-deployment.yaml
+++ b/charts/connect/templates/connect-deployment.yaml
@@ -61,11 +61,6 @@ spec:
           resources:
             {{- toYaml .Values.connect.api.resources | nindent 12 }}
           env:
-            - name: OP_SESSION
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.connect.credentialsName }}
-                  key: {{ .Values.connect.credentialsKey }}
             - name: OP_BUS_PORT
               value: "11220"
             - name: OP_BUS_PEERS
@@ -113,6 +108,9 @@ spec:
             - name: tls-cert
               mountPath: /home/opuser/.op/certs
             {{- end }}
+            - mountPath: /home/opuser/.op/1password-credentials.json
+              name: credentials
+              subPath: {{ .Values.connect.credentialsKey }}
         - name: connect-sync
           image: {{ .Values.connect.sync.imageRepository }}:{{ tpl .Values.connect.version . }}
           imagePullPolicy: {{ .Values.connect.imagePullPolicy }}
@@ -125,11 +123,6 @@ spec:
           env:
             - name: OP_HTTP_PORT
               value: "{{ .Values.connect.sync.httpPort }}"
-            - name: OP_SESSION
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.connect.credentialsName }}
-                  key: {{ .Values.connect.credentialsKey }}
             - name: OP_BUS_PORT
               value: "11221"
             - name: OP_BUS_PEERS
@@ -157,6 +150,9 @@ spec:
           volumeMounts:
             - mountPath: /home/opuser/.op/data
               name: {{ .Values.connect.dataVolume.name }}
+            - mountPath: /home/opuser/.op/1password-credentials.json
+              name: credentials
+              subPath: {{ .Values.connect.credentialsKey }}
         {{- if .Values.connect.profiler.enabled }}
         - name: profiler-data
           image: alpine


### PR DESCRIPTION
Using the credentials as `OP_SESSION` is confusing, as it requires you to base64 encode the 1password-credentials.json file first. That's on top of having to base64 encode the secret in k8s. This twice base64- encoding is undocumented and unintuitve.

Since connect supports reading the credentials from disk, and we already create the volume from the secret anyway, just follow thru and mount the credentials at the expected location. I imagine this was the intent at some point.

As a sidebar: it was extra weird to find that `OP_SESSION` has a second use: it can also be used to override the location of `1password-credentials.json`. I would advise separating these into two separate environment variables but that's out of scope for this change.

Finally, since we're mounting the file and not _trying_ to double-base64 the data, swap `stringData` for `data` in the secret.

Obsoletes pull request #113, fixes issue #163 and issue #94, makes some progress on issue #167.