### PR TITLE
Update to Connect 1.7.3

### DIFF
--- a/charts/connect/CHANGELOG.md
+++ b/charts/connect/CHANGELOG.md
@@ -13,6 +13,14 @@
 ---
 
 [//]: # (START/v1.15.0)
+# v1.15.1
+
+## Features
+* Bump Connect version to v1.7.3
+
+---
+
+[//]: # (START/v1.15.0)
 # v1.15.0
 
 ## Features

--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: connect
-version: 1.15.0
+version: 1.15.1
 description: A Helm chart for deploying 1Password Connect and the 1Password Connect Kubernetes Operator
 keywords:
   - "1Password"
@@ -11,4 +11,4 @@ maintainers:
   - name: 1Password Secrets Integrations Team
     email: support+business@1password.com
 icon: https://avatars.githubusercontent.com/u/38230737
-appVersion: "1.7.2"
+appVersion: "1.7.3"


### PR DESCRIPTION
This PR bumps the Connect version used by Helm charts to v1.7.3.

This PR will also make a new Helm chart release which will use Connect v1.7.3