### PR TITLE
Use request instead of limits for cpu resource

### DIFF
--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -21,7 +21,8 @@ connect:
     resources:
       limits:
         memory: 128Mi
-        cpu: 0.2
+      requests:
+        cpu: 0.2m
     httpPort: 8080
     httpsPort: 8443
     logLevel: info

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -22,7 +22,7 @@ connect:
       limits:
         memory: 128Mi
       requests:
-        cpu: 0.2m
+        cpu: 0.2
     httpPort: 8080
     httpsPort: 8443
     logLevel: info


### PR DESCRIPTION
Since CPU is a compressible resource it makes sense for us not to limit it. Furthermore, since we want to meet the conditions for our node to be catalogued as `burstable` by Kubernetes we want to provide a `request` spec.