### PR TITLE
Fix podDisruptionBudget labels

### DIFF
--- a/charts/connect/templates/connect-pdb.yaml
+++ b/charts/connect/templates/connect-pdb.yaml
@@ -9,10 +9,11 @@ metadata:
     {{- include "onepassword-connect.labels" . | nindent 4 }}
 {{- include "onepassword-connect.extraAnnotations" .Values.connect.pdb }}
 spec:
-  {{- with .Values.connect.pdb.maxUnavailable }}
-  maxUnavailable: {{ . }}
-  {{- else }}
+  {{- if .Values.connect.pdb.minAvailable }}
   minAvailable: {{ .Values.connect.pdb.minAvailable }}
+  {{- end }}
+  {{- if and .Values.connect.pdb.maxUnavailable (not .Values.connect.pdb.minAvailable)}}
+  maxUnavailable: {{ .Values.connect.pdb.maxUnavailable }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/connect/templates/connect-pdb.yaml
+++ b/charts/connect/templates/connect-pdb.yaml
@@ -9,11 +9,10 @@ metadata:
     {{- include "onepassword-connect.labels" . | nindent 4 }}
 {{- include "onepassword-connect.extraAnnotations" .Values.connect.pdb }}
 spec:
-  {{- if .Values.connect.pdb.minAvailable }}
+  {{- with .Values.connect.pdb.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- else }}
   minAvailable: {{ .Values.connect.pdb.minAvailable }}
-  {{- end }}
-  {{- if and .Values.connect.pdb.maxUnavailable (not .Values.connect.pdb.minAvailable)}}
-  maxUnavailable: {{ .Values.connect.pdb.maxUnavailable }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/connect/templates/connect-pdb.yaml
+++ b/charts/connect/templates/connect-pdb.yaml
@@ -17,5 +17,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: connect
-      {{- include "onepassword-connect.selectorLabels" . | nindent 6 }}
+      app: {{ .Values.connect.applicationName }}
 {{- end }}

--- a/charts/connect/templates/operator-pdb.yaml
+++ b/charts/connect/templates/operator-pdb.yaml
@@ -17,5 +17,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: operator
-      {{- include "onepassword-connect.selectorLabels" . | nindent 6 }}
+      name: {{ .Values.connect.applicationName }}
 {{- end }}

--- a/charts/connect/templates/operator-pdb.yaml
+++ b/charts/connect/templates/operator-pdb.yaml
@@ -9,10 +9,11 @@ metadata:
     {{- include "onepassword-connect.labels" . | nindent 4 }}
 {{- include "onepassword-connect.extraAnnotations" .Values.operator.pdb }}
 spec:
-  {{- with .Values.operator.pdb.maxUnavailable }}
-  maxUnavailable: {{ . }}
-  {{- else }}
+  {{- if .Values.operator.pdb.minAvailable }}
   minAvailable: {{ .Values.operator.pdb.minAvailable }}
+  {{- end }}
+  {{- if and .Values.operator.pdb.maxUnavailable (not .Values.operator.pdb.minAvailable)}}
+  maxUnavailable: {{ .Values.operator.pdb.maxUnavailable }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/connect/templates/operator-pdb.yaml
+++ b/charts/connect/templates/operator-pdb.yaml
@@ -9,11 +9,10 @@ metadata:
     {{- include "onepassword-connect.labels" . | nindent 4 }}
 {{- include "onepassword-connect.extraAnnotations" .Values.operator.pdb }}
 spec:
-  {{- if .Values.operator.pdb.minAvailable }}
+  {{- with .Values.operator.pdb.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- else }}
   minAvailable: {{ .Values.operator.pdb.minAvailable }}
-  {{- end }}
-  {{- if and .Values.operator.pdb.maxUnavailable (not .Values.operator.pdb.minAvailable)}}
-  maxUnavailable: {{ .Values.operator.pdb.maxUnavailable }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -131,10 +131,10 @@ connect:
     enabled: false
     # Additional annotations to be added to the PDB Connect
     annotations: {}
-    # Number of pods that are available after eviction as number or percentage (eg.: 50%)
-    # minAvailable: 1
     # Number of pods that are unavailble after eviction as number or percentage (eg.: 50%)
-    # maxUnavailable: 1
+    maxUnavailable: 1
+    # Number of pods that are available after eviction as number or percentage (eg.: 50%)
+    minAvailable: 0
 
   # 1Password Connect API and Sync Service
   probes:
@@ -295,10 +295,10 @@ operator:
     enabled: false
     # Additional annotations to be added to the PDB Operator
     annotations: {}
-    # Number of pods that are available after eviction as number or percentage (eg.: 50%)
-    # minAvailable: 1
     # Number of pods that are unavailble after eviction as number or percentage (eg.: 50%)
-    # maxUnavailable: 1
+    maxUnavailable: 1
+    # Number of pods that are available after eviction as number or percentage (eg.: 50%)
+    minAvailable: 0
 
   # Additional annotations to be added to the Operator pods.
   annotations: {}

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -131,10 +131,10 @@ connect:
     enabled: false
     # Additional annotations to be added to the PDB Connect
     annotations: {}
-    # Number of pods that are unavailble after eviction as number or percentage (eg.: 50%)
-    maxUnavailable: 1
     # Number of pods that are available after eviction as number or percentage (eg.: 50%)
-    minAvailable: 0
+    # minAvailable: 1
+    # Number of pods that are unavailble after eviction as number or percentage (eg.: 50%)
+    # maxUnavailable: 1
 
   # 1Password Connect API and Sync Service
   probes:
@@ -295,10 +295,10 @@ operator:
     enabled: false
     # Additional annotations to be added to the PDB Operator
     annotations: {}
-    # Number of pods that are unavailble after eviction as number or percentage (eg.: 50%)
-    maxUnavailable: 1
     # Number of pods that are available after eviction as number or percentage (eg.: 50%)
-    minAvailable: 0
+    # minAvailable: 1
+    # Number of pods that are unavailble after eviction as number or percentage (eg.: 50%)
+    # maxUnavailable: 1
 
   # Additional annotations to be added to the Operator pods.
   annotations: {}


### PR DESCRIPTION
Current pod disruption budget objects are not working correctly because of their labels. The labels matching the pods use the deployment labels instead of the pod ones. Because of that, the `pdbs` never identify the pods managed by the deployments.

Deployment labels

```yaml
app.kubernetes.io/component=connect
app.kubernetes.io/instance=connect
app.kubernetes.io/managed-by=Helm
app.kubernetes.io/name=connect
app.kubernetes.io/version=1.7.3
helm.sh/chart=connect-1.16.0
```

Pod labels

```yaml
app=onepassword-connect
app.kubernetes.io/component=connect
```

A second issue identified in the pod disruption objects is the lack of an option to set up the `minAvailable` feature. The solution included in the merge request allows the use of `minAvailable` or `maxUnavailable`.