### PR TITLE
Prepare Connect Helm chart release 1.17.0

### DIFF
--- a/charts/connect/CHANGELOG.md
+++ b/charts/connect/CHANGELOG.md
@@ -11,6 +11,15 @@
 ## Security
 * A user-friendly description of a security fix. {issue-number}
 
+[//]: # (START/v1.17.0)
+# v1.17.0
+
+## Features
+* Add resources defaults to limit connect API's resource consumption. (#209, #211)
+
+## Fixes
+* Fix `podDisruptionBudget` labels. Credits to @mmorejon for the contribution. (#213)
+
 [//]: # (START/v1.16.0)
 # v1.16.0
 

--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: connect
-version: 1.16.0
+version: 1.17.0
 description: A Helm chart for deploying 1Password Connect and the 1Password Connect Kubernetes Operator
 keywords:
   - "1Password"


### PR DESCRIPTION
## Features
* Add resources defaults to limit connect API's resource consumption. (#209, #211)

## Fixes
* Fix `podDisruptionBudget` labels. Credits to @mmorejon for the contribution. (#213)