### PR TITLE
ci: push Helm Chart to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release charts if needed
+name: Release Charts
 
 on:
   push:
@@ -7,29 +7,45 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write # for helm/chart-releaser-action to push chart release and create a release
+      packages: write # for pushing chart to the GHCR registry
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Configure Git
         run: |
-          # Authenticate as the GitHub Actions bot https://api.github.com/users/github-actions%5Bbot%5D
-          git config user.name "GitHub Actions"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: v3.4.1
+        uses: azure/setup-helm@v4
 
       - name: Run chart-releaser
-        # Fork of helm/chart-releaser-action to avoid unwanted release attempts.
-        # Upstream PR: https://github.com/helm/chart-releaser-action/pull/80
-        uses: florisvdg/chart-releaser-action@v1.3.0
-        with:
-          charts_dir: charts
+        uses: helm/chart-releaser-action@v1.7.0
+        id: cr
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_SKIP_EXISTING: true
+          
+      - if: ${{ steps.cr.outputs.changed_charts }}
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: ${{ steps.cr.outputs.changed_charts }}
+        name: Push Charts to GHCR
+        run: |
+          for pkg in .cr-release-packages/*; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" oci://ghcr.io/${{ github.repository }}
+          done


### PR DESCRIPTION
>[!IMPORTANT]
> After this is merged and charts are released you might need to make the packages public from [here](https://github.com/orgs/1Password/packages)

I also bumped some deps as well and switched back to the official chart releaser action.

Fixes: #221