### PR TITLE
#224 Remove permissions when serviceMonitor.enabled is false

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.12
 
       - name: Set up ct CLI
         uses: helm/chart-testing-action@v2.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,9 +55,9 @@ jobs:
         env:
           OP_CONNECT_CREDENTIALS: ${{ secrets.OP_CONNECT_CREDENTIALS }}
           OP_CONNECT_TOKEN: ${{ secrets.OP_CONNECT_TOKEN }}
-          OP_VAULT_ID: ${{ vars.OP_VAULT_ID || "v5pz6venw4roosmkzdq2nhpv6u" }}
-          OP_ITEM_ID: ${{ vars.OP_ITEM_ID || "hrgkzhrlvscomepxlgafb2m3ca" }}
-          OP_SECRET_VALUE: ${{ vars.OP_SECRET_VALUE || "RGVhciBzZWN1cml0eSByZXNlYXJjaGVyLCB0aGlzIGlzIGp1c3QgYSBkdW1teSBzZWNyZXQuIFBsZWFzZSBkb24ndCByZXBvcnQgaXQu" }}
+          OP_VAULT_ID: ${{ vars.OP_VAULT_ID || 'v5pz6venw4roosmkzdq2nhpv6u' }}
+          OP_ITEM_ID: ${{ vars.OP_ITEM_ID || 'hrgkzhrlvscomepxlgafb2m3ca' }}
+          OP_SECRET_VALUE: ${{ vars.OP_SECRET_VALUE || 'RGVhciBzZWN1cml0eSByZXNlYXJjaGVyLCB0aGlzIGlzIGp1c3QgYSBkdW1teSBzZWNyZXQuIFBsZWFzZSBkb24ndCByZXBvcnQgaXQu' }}
         run: |
           cat > fixtures.yaml << EOF
           acceptanceTests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,14 +55,17 @@ jobs:
         env:
           OP_CONNECT_CREDENTIALS: ${{ secrets.OP_CONNECT_CREDENTIALS }}
           OP_CONNECT_TOKEN: ${{ secrets.OP_CONNECT_TOKEN }}
+          OP_VAULT_ID: ${{ vars.OP_VAULT_ID || "v5pz6venw4roosmkzdq2nhpv6u" }}
+          OP_ITEM_ID: ${{ vars.OP_ITEM_ID || "hrgkzhrlvscomepxlgafb2m3ca" }}
+          OP_SECRET_VALUE: ${{ vars.OP_SECRET_VALUE || "RGVhciBzZWN1cml0eSByZXNlYXJjaGVyLCB0aGlzIGlzIGp1c3QgYSBkdW1teSBzZWNyZXQuIFBsZWFzZSBkb24ndCByZXBvcnQgaXQu" }}
         run: |
           cat > fixtures.yaml << EOF
           acceptanceTests:
             enabled: true
             fixtures:
-              vaultId: v5pz6venw4roosmkzdq2nhpv6u
-              itemId: hrgkzhrlvscomepxlgafb2m3ca
-              secretValue: RGVhciBzZWN1cml0eSByZXNlYXJjaGVyLCB0aGlzIGlzIGp1c3QgYSBkdW1teSBzZWNyZXQuIFBsZWFzZSBkb24ndCByZXBvcnQgaXQu
+              vaultId: $OP_VAULT_ID
+              itemId: $OP_ITEM_ID
+              secretValue: $OP_SECRET_VALUE
           EOF
 
           for values_file in charts/connect/ci/*.yaml; do

--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: connect
-version: 1.17.0
+version: 1.17.1
 description: A Helm chart for deploying 1Password Connect and the 1Password Connect Kubernetes Operator
 keywords:
   - "1Password"

--- a/charts/connect/templates/clusterrole.yaml
+++ b/charts/connect/templates/clusterrole.yaml
@@ -42,6 +42,7 @@ rules:
   - patch
   - update
   - watch
+{{- if .Values.connect.api.serviceMonitor.enabled }}
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -49,6 +50,7 @@ rules:
   verbs:
   - get
   - create
+{{- end }}
 - apiGroups:
   - apps
   resourceNames:


### PR DESCRIPTION
# Changes
- Adds conditional templating logic that prevents the helm template from generating unnecessary rules for 1Password Connect Operator when serviceMonitor support is disabled.
- Fixes lint workflow by updating python version from 3.7 to 3.12.
- Enables execution of test workflow in forked repositories by allowing optional injection of vault id, item id and secret value using repository variables.

# Resolves
- #224