### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/charts/connect/CHANGELOG.md
+++ b/charts/connect/CHANGELOG.md
@@ -11,6 +11,12 @@
 ## Security
 * A user-friendly description of a security fix. {issue-number}
 
+[//]: # (START/v1.17.1)
+# v1.17.1
+
+## Fixes
+* Apply ServiceMonitor rules conditionally by providing value. Credits to @estenrye for the contribution. (#224)
+
 [//]: # (START/v1.17.0)
 # v1.17.0
 


### PR DESCRIPTION
Connect helm chart version is updated in https://github.com/1Password/connect-helm-charts/pull/225.

This PR just a followup to update changelog with that fix.