### PR TITLE
Make it possible to upgrade connect chart to v2.0.x without providing token value

### DIFF
--- a/charts/connect/templates/operator-deployment.yaml
+++ b/charts/connect/templates/operator-deployment.yaml
@@ -72,14 +72,14 @@ spec:
               value: "{{ .Values.operator.pollingInterval }}"
             - name: AUTO_RESTART
               value: "{{ .Values.operator.autoRestart }}"
-            {{- if .Values.operator.serviceAccountToken.value }}
+            {{- if .Values.operator.useWithServiceAccount }}
             - name: OP_SERVICE_ACCOUNT_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.operator.serviceAccountToken.name }}
                   key: {{ .Values.operator.serviceAccountToken.key }}
             {{- end }}
-            {{- if .Values.operator.token.value }}
+            {{- if .Values.operator.useWithConnect }}
             - name: OP_CONNECT_HOST
               value: "{{- include "onepassword-connect.url" . }}"
             - name: OP_CONNECT_TOKEN

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -241,6 +241,12 @@ operator:
   # Denotes whether the 1Password Operator will be deployed
   create: false
 
+  # Denotes whether the 1Password Operator will use 1Password Connect to access secrets
+  useWithConnect: true
+
+  # Denotes whether the 1Password Operator will use 1Password Service Account to access secrets
+  useWithServiceAccount: false
+
   # The number of replicas to run the 1Password Connect Operator deployment
   replicas: 1
 


### PR DESCRIPTION
After `v2.0.0` release users started to face the issue that after upgrade Operator doesn't work as `OP_CONNECT_TOKEN` and `OP_CONNECT_HOST` env vars are not set for the pod. (https://github.com/1Password/connect-helm-charts/issues/231)

This happens as the Connect token value is not provided in the upgrade config, for example when upgrading with Flux
```
  values:
    connect:
      create: true
    operator:
      create: true
      token:
        name: onepassword-token
```
As users expect that it would use the secret that was previously created. 
And because Connect token value is missed, it never adds Connect env vars to the POD.

This PR fixes that allowing to use the same secrets (Connect credentials) after the upgrade to the newer versions.
It introduces 2 new flags `operator.useWithConnect` which is `true` by default and `operator.useWithServiceAccount`, which is `false` by default.
And `charts/connect/templates/operator-deployment.yaml` is updated to add corresponding env vars to the deployment. 

With that, it allows seamless upgrade, if users still want to continue using Operator with Connect, without a need to modify their existing release configs or helm upgrade commands, as useWithConnect by default is `true`.


Resolves: https://github.com/1Password/connect-helm-charts/issues/231