### PR TITLE
connect: allow specifying test image and disabling tests

### DIFF
--- a/charts/connect/templates/tests/health-check.yml
+++ b/charts/connect/templates/tests/health-check.yml
@@ -1,4 +1,4 @@
-{{- if .Values.connect.create }}
+{{- if and .Values.acceptanceTests.healthCheck.enabled .Values.connect.create }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -13,6 +13,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: curl
-      image: curlimages/curl
+      image: {{ .Values.acceptanceTests.healthCheck.image.repository }}:{{ .Values.acceptanceTests.healthCheck.image.tag }}
+
       command: ["curl", "{{- include "onepassword-connect.url" . }}/health"]
 {{- end }}

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -400,3 +400,8 @@ operator:
 acceptanceTests:
   enabled: false
   fixtures: {}
+  healthCheck:
+    enabled: true
+    image:
+      repository: curlimages/curl
+      tag: 'latest'


### PR DESCRIPTION
We are happily using this helm chart, but due to compliance, I need two features:

1) Allowing to disable health check tests
2) Allowing to specify custom image for those tests

This PR is implementing both at the same time.

I followed the pattern used by `.Values. acceptanceTests` and for setting image, I used what is a defacto standard and what was compatible with [renovate](https://docs.renovatebot.com/)