### PR TITLE
Prepare release v2.0.3 for connect chart

### DIFF
--- a/charts/connect/CHANGELOG.md
+++ b/charts/connect/CHANGELOG.md
@@ -10,6 +10,12 @@
 ## Security
 * A user-friendly description of a security fix. {issue-number}
 
+[//]: # (START/v2.0.3)
+# v2.0.3
+
+## Fixes
+* Allow disabling healthCheck test and allow specifying image used in that test. (#241)
+
 [//]: # (START/v2.0.2)
 # v2.0.2
 

--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: connect
-version: 2.0.2
+version: 2.0.3
 description: A Helm chart for deploying 1Password Connect and the 1Password Connect Kubernetes Operator
 keywords:
   - "1Password"


### PR DESCRIPTION
I was wondering if it would be possible to have a release for connect helm chart which includes a bugfix from #241 . It would help me a bit. To speed up the process, I created this PR with a release 2.0.3 while following what was done for 2.0.2 in https://github.com/1Password/connect-helm-charts/pull/237

Sorry for brevity.

cc @volodymyrZotov