### PR TITLE
Prepare release v2.0.4

### DIFF
--- a/charts/connect/CHANGELOG.md
+++ b/charts/connect/CHANGELOG.md
@@ -10,6 +10,12 @@
 ## Security
 * A user-friendly description of a security fix. {issue-number}
 
+[//]: # (START/v2.0.4)
+# v2.0.4
+
+## Features
+* Bump Connect version to v1.8.0
+
 [//]: # (START/v2.0.3)
 # v2.0.3
 

--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: connect
-version: 2.0.3
+version: 2.0.4
 description: A Helm chart for deploying 1Password Connect and the 1Password Connect Kubernetes Operator
 keywords:
   - "1Password"
@@ -11,4 +11,4 @@ maintainers:
   - name: 1Password Secrets Integrations Team
     email: support+business@1password.com
 icon: https://avatars.githubusercontent.com/u/38230737
-appVersion: "1.7.3"
+appVersion: "1.8.0"


### PR DESCRIPTION
This PR makes Connect helm chart to use Connect image `v1.8.0` and bumps chart version to `v2.0.4`

Resolves #220 