### PR TITLE
Fixed customEnvVars feature

### DIFF
--- a/charts/connect/templates/connect-deployment.yaml
+++ b/charts/connect/templates/connect-deployment.yaml
@@ -144,6 +144,10 @@ spec:
             - name: OP_LOG_LEVEL
               value: "{{ .Values.connect.sync.logLevel }}"
             {{- include "onepassword-connect.profilerConfig" . | indent 12 }}
+            {{- range .Values.connect.customEnvVars }}
+            - name: {{ .name }}
+              value: {{ .value }}
+            {{- end }}
           {{- if .Values.connect.probes.readiness }}
           readinessProbe:
             httpGet:


### PR DESCRIPTION
This feature was introduced incorrectly january 2024.
It was implemented to allow for setting proxy variables. However the vars are only set for the api container and not set for the sync container which is the component that needs to connect to the cloud.