### PR TITLE
Revert back to using forked chart-releaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,11 @@ jobs:
         uses: azure/setup-helm@v4
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
+        # Fork of helm/chart-releaser-action to avoid unwanted release attempts.
+        # Upstream PR: https://github.com/helm/chart-releaser-action/pull/80
+        uses: florisvdg/chart-releaser-action@v1.3.0
+        with:
+          charts_dir: charts
         id: cr
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
### ✨ Summary
Currently, release job wants to release new helm version when any file is changed.
<img width="1282" height="395" alt="Screenshot 2025-12-02 at 4 04 59 PM" src="https://github.com/user-attachments/assets/0724f46b-0749-4671-91a6-3ce7f9a844cd" />

This was introduced in the [PR ](https://github.com/1Password/connect-helm-charts/pull/222/files) which adds publishing images to ghcr.

This is not the behaviour we want to follow. So, revert back to using forked chart-releaser. Which released only when char version was changed.


### 🔗 Resolves:
<!-- What issue does it resolve? -->

### ✅ Checklist
- [x] 🖊️ Commits are signed
- [ ] 🧪 Tests added/updated
- [ ] 📚 Docs updated (if behavior changed)

### 🕵️ Review Notes & ⚠️ Risks
<!-- Notes for reviewers, flags, feature gates, rollout considerations, etc. -->
