### PR TITLE
Fix pushing to ghcr in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: true
-          
+
       - if: ${{ steps.cr.outputs.changed_charts }}
         name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -54,5 +54,5 @@ jobs:
             if [ -z "${pkg:-}" ]; then
               break
             fi
-            helm push "${pkg}" oci://ghcr.io/${{ github.repository }}
+            helm push "${pkg}" oci://ghcr.io/${GITHUB_REPOSITORY_OWNER,,} # convert repository owner to lowercase
           done


### PR DESCRIPTION
### ✨ Summary
This PR fixes pushing chart to ghcr.

It starts to use github repo owner in ghcr link, also makes sure `1password` is in lower case.

### 🔗 Resolves:
<!-- What issue does it resolve? -->

### ✅ Checklist
- [x] 🖊️ Commits are signed
- [ ] 🧪 Tests added/updated
- [ ] 📚 Docs updated (if behavior changed)

### 🕵️ Review Notes & ⚠️ Risks
<!-- Notes for reviewers, flags, feature gates, rollout considerations, etc. -->
