### PR TITLE
Fix pushing a release to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,19 @@ jobs:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: true
 
-      - if: ${{ steps.cr.outputs.changed_charts }}
+      - name: Check for released packages
+        id: check_packages
+        run: |
+          if [ -d ".cr-release-packages" ] && [ -n "$(ls -A .cr-release-packages/ 2>/dev/null)" ]; then
+            echo "has_packages=true" >> $GITHUB_OUTPUT
+            echo "Found packages:"
+            ls -la .cr-release-packages/
+          else
+            echo "has_packages=false" >> $GITHUB_OUTPUT
+            echo "No packages found"
+          fi
+
+      - if: ${{ steps.check_packages.outputs.has_packages == 'true' }}
         name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -47,12 +59,9 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - if: ${{ steps.cr.outputs.changed_charts }}
+      - if: ${{ steps.check_packages.outputs.has_packages == 'true' }}
         name: Push Charts to GHCR
         run: |
           for pkg in .cr-release-packages/*; do
-            if [ -z "${pkg:-}" ]; then
-              break
-            fi
             helm push "${pkg}" oci://ghcr.io/${GITHUB_REPOSITORY_OWNER,,} # convert repository owner to lowercase
           done


### PR DESCRIPTION
### ✨ Summary

`florisvdg/chart-releaser-action@v1.3.0` action fork we are using makes chart releases only when the version in `Chart.yaml` file is updated. Which is fine, but it has an issue with returning results in `outputs.changed_charts`.

Therefore a new `Check for released packages` step is introduced, which checks if there any packages are in `.cr-release-packages`, and if so, that means release to GHCR registry is needed. That step returns `"has_packages=false"` and the next steps have `if: ${{ steps.check_packages.outputs.has_packages == 'true' }}` check and will run only when release is needed.

Tested it in my forked repo.
[This workflow](https://github.com/volodymyrZotov/connect-helm-charts/actions/runs/20144427199/job/57820774771)
shows that it publishes to GHCR, and package is available as [ghcr package](https://github.com/volodymyrZotov?tab=packages) and can be fetched using `helm pull oci://ghcr.io/volodymyrzotov/connect --version 2.1.4` command.

And [another workflow](https://github.com/volodymyrZotov/connect-helm-charts/actions/runs/20144508903) shows that it skipped pushing to GHCR as chart version remained the same.

### 🔗 Resolves:
<!-- What issue does it resolve? -->

### ✅ Checklist
- [x] 🖊️ Commits are signed
- [ ] 🧪 Tests added/updated
- [ ] 📚 Docs updated (if behavior changed)

### 🕵️ Review Notes & ⚠️ Risks
<!-- Notes for reviewers, flags, feature gates, rollout considerations, etc. -->
