### PR TITLE
Fix OP_SESSION credential reference

### DIFF
--- a/charts/connect/templates/connect-deployment.yaml
+++ b/charts/connect/templates/connect-deployment.yaml
@@ -69,7 +69,7 @@ spec:
             {{- toYaml .Values.connect.api.resources | nindent 12 }}
           env:
             - name: OP_SESSION
-              value: /home/opuser/.op/{{ .Values.connect.credentialsKey }}
+              value: /home/opuser/.op/credentials/{{ .Values.connect.credentialsKey }}
             - name: OP_BUS_PORT
               value: "11220"
             - name: OP_BUS_PEERS
@@ -113,7 +113,7 @@ spec:
           volumeMounts:
             - mountPath: /home/opuser/.op/data
               name: {{ .Values.connect.dataVolume.name }}
-            - mountPath: /home/opuser/.op/{{ .Values.connect.credentialsKey }}
+            - mountPath: /home/opuser/.op/credentials
               name: credentials
             {{- if .Values.connect.tls.enabled }}
             - name: tls-cert
@@ -132,7 +132,7 @@ spec:
             - name: OP_HTTP_PORT
               value: "{{ .Values.connect.sync.httpPort }}"
             - name: OP_SESSION
-              value: /home/opuser/.op/{{ .Values.connect.credentialsKey }}
+              value: /home/opuser/.op/credentials/{{ .Values.connect.credentialsKey }}
             - name: OP_BUS_PORT
               value: "11221"
             - name: OP_BUS_PEERS
@@ -164,7 +164,7 @@ spec:
           volumeMounts:
             - mountPath: /home/opuser/.op/data
               name: {{ .Values.connect.dataVolume.name }}
-            - mountPath: /home/opuser/.op/{{ .Values.connect.credentialsKey }}
+            - mountPath: /home/opuser/.op/credentials
               name: credentials
         {{- if .Values.connect.profiler.enabled }}
         - name: profiler-data


### PR DESCRIPTION
### ✨ Summary
<!-- What does this change do? -->
Based on documentation for the container [1password/connect-api(https://hub.docker.com/r/1password/connect-api), `OP_SESSION` should be pointing to the path where credentials are stored, not the raw JSON itself. This change mounts the already existing `credentials` volume into both containers and sets `OP_SESSION` to reference credentials JSON.

There's an argument to be made that you could use a subPath to mount the credentials file directly but I chose not to since Kubernetes docs mention that a secret mounted with a subPath will not receive updates:

https://kubernetes.io/docs/concepts/storage/volumes/#secret

### 🔗 Resolves:
<!-- What issue does it resolve? -->

### ✅ Checklist
- [X] 🖊️ Commits are signed
- [ ] 🧪 Tests added/updated
- [ ] 📚 Docs updated (if behavior changed)

### 🕵️ Review Notes & ⚠️ Risks
<!-- Notes for reviewers, flags, feature gates, rollout considerations, etc. -->
