### PR TITLE
feat(connect): add Gateway API HTTPRoute support as alternative to Ingress

### DIFF
--- a/charts/connect/README.md
+++ b/charts/connect/README.md
@@ -113,6 +113,12 @@ To disable this, you can run `helm install` with the [`--skip-crds` flag](https:
 | connect.hpa.enabled | bool | `false` | Enable Horizontal Pod Autoscaling for the Connect pod |
 | connect.hpa.maxReplicas | int | `3` | Maximum number of replicas for the Connect pod |
 | connect.hpa.minReplicas | int | `1` | Minimum number of replicas for the Connect pod |
+| connect.httpRoute.annotations | object | `{}` | Additional annotations to be added to the HTTPRoute resource |
+| connect.httpRoute.enabled | bool | `false` | Enable the creation of a Gateway API HTTPRoute resource for the Connect API |
+| connect.httpRoute.hostnames | list | `[]` | Hostnames that the HTTPRoute should match |
+| connect.httpRoute.labels | object | `{}` | Additional labels to be added to the HTTPRoute resource |
+| connect.httpRoute.parentRefs | list | `[]` | Parent references to Gateway resources. At least one is required when enabled. ref: https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#parentreference |
+| connect.httpRoute.rules | list | `[]` (See [values.yaml]) | HTTPRoute rules configuration. The default backendRefs service name and port are automatically set from connect.applicationName and the API port. ref: https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httprouterule |
 | connect.imagePullPolicy | string | `"IfNotPresent"` | The 1Password Connect API image pull policy |
 | connect.imagePullSecrets | list | `[]` | List of secret names to use as image pull secrets. Secrets must exist in the same namespace. |
 | connect.ingress.annotations | object | `{}` | The 1Password Connect Ingress Annotations |

--- a/charts/connect/ci/with-httproute-values.yaml
+++ b/charts/connect/ci/with-httproute-values.yaml
@@ -1,0 +1,13 @@
+# Deploys Connect with an HTTPRoute instead of Ingress
+connect:
+  httpRoute:
+    enabled: true
+    parentRefs:
+      - name: test-gateway
+        namespace: default
+    hostnames:
+      - connect.example.com
+    labels:
+      traffic: external
+    annotations:
+      example.com/test: "true"

--- a/charts/connect/templates/httproute.yaml
+++ b/charts/connect/templates/httproute.yaml
@@ -1,0 +1,51 @@
+{{- if and (.Values.connect.httpRoute.enabled) (.Values.connect.create) -}}
+{{- if .Values.connect.ingress.enabled -}}
+{{- fail "connect.ingress.enabled and connect.httpRoute.enabled are mutually exclusive" -}}
+{{- end -}}
+{{- if not .Values.connect.httpRoute.parentRefs -}}
+{{- fail "connect.httpRoute.parentRefs must specify at least one Gateway reference when connect.httpRoute.enabled is true" -}}
+{{- end -}}
+{{- $serviceName := .Values.connect.applicationName -}}
+{{- $tlsEnabled := .Values.connect.tls.enabled -}}
+{{- $apiHttpPort := .Values.connect.api.httpPort -}}
+{{- $apiHttpsPort := .Values.connect.api.httpsPort -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ template "onepassword-connect.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "onepassword-connect.labels" . | nindent 4 }}
+    {{- with .Values.connect.httpRoute.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.connect.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.connect.httpRoute.parentRefs | nindent 4 }}
+  {{- with .Values.connect.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.connect.httpRoute.rules }}
+    - {{- if .matches }}
+      matches:
+        {{- toYaml .matches | nindent 8 }}
+      {{- end }}
+      {{- if .filters }}
+      filters:
+        {{- toYaml .filters | nindent 8 }}
+      {{- end }}
+      backendRefs:
+      {{- if .backendRefs }}
+        {{- toYaml .backendRefs | nindent 8 }}
+      {{- else }}
+        - name: {{ $serviceName }}
+          port: {{ if $tlsEnabled }}{{ $apiHttpsPort }}{{ else }}{{ $apiHttpPort }}{{ end }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -250,6 +250,35 @@ connect:
     #    hosts:
     #      - chart-example.local
 
+  # HTTPRoute allows creating a Gateway API HTTPRoute resource as an alternative to Ingress.
+  # Cannot be enabled at the same time as ingress.
+  # ref: https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httproute
+  httpRoute:
+    # -- Enable the creation of a Gateway API HTTPRoute resource for the Connect API
+    enabled: false
+    # -- Additional labels to be added to the HTTPRoute resource
+    labels: {}
+    # -- Additional annotations to be added to the HTTPRoute resource
+    annotations: {}
+    # -- Parent references to Gateway resources. At least one is required when enabled.
+    # ref: https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#parentreference
+    parentRefs: []
+    #  - name: my-gateway
+    #    namespace: gateway-ns
+    #    sectionName: https
+    # -- Hostnames that the HTTPRoute should match
+    hostnames: []
+    #  - chart-example.local
+    # -- HTTPRoute rules configuration.
+    # The default backendRefs service name and port are automatically set from connect.applicationName and the API port.
+    # ref: https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httprouterule
+    # @default -- `[]` (See [values.yaml])
+    rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /
+
   # Optionally the internal profiler can be enabled to debug memory or performance issues.
   profiler:
     # -- Enable the internal profiler to debug memory or performance issues. For normal operation this does not have to be enabled.


### PR DESCRIPTION
### ✨ Summary

Add support for creating a [Gateway API](https://gateway-api.sigs.k8s.io/) `HTTPRoute` resource as an alternative to the existing `Ingress` for exposing the Connect API server.

Gateway API is the successor to the Ingress API, GA since Kubernetes 1.26, and is increasingly the standard for traffic routing in modern clusters. This change introduces a new `connect.httpRoute` values section that generates a `gateway.networking.k8s.io/v1` `HTTPRoute` resource when enabled.

**What's included:**

- **New template** (`templates/httproute.yaml`) — renders an `HTTPRoute` with:
  - Shared chart labels via `onepassword-connect.labels` helper
  - Optional custom labels, annotations, and hostnames
  - Configurable routing rules with auto-injected `backendRefs` (service name and port derived from `connect.applicationName` and `connect.api.httpPort`/`connect.api.httpsPort` based on TLS config)
  - User-supplied `backendRefs` override per rule when needed
- **New values** (`values.yaml`) — `connect.httpRoute` section with a sensible default rule (`PathPrefix: /`)
- **Validation guards:**
  - `fail` if both `connect.ingress.enabled` and `connect.httpRoute.enabled` are `true` (mutually exclusive)
  - `fail` if `connect.httpRoute.enabled` is `true` but `parentRefs` is empty
- **CI test values** (`ci/with-httproute-values.yaml`) for chart-testing
- **README regenerated** via `helm-docs`

### 🔗 Resolves

Closes #285

### ✅ Checklist
- [x] 🖊️ Commits are signed
- [x] 🧪 Tests added/updated
- [x] 📚 Docs updated (if behavior changed)

### 🕵️ Review Notes & ⚠️ Risks

**Design decisions:**
- Default routing rule (`PathPrefix: /`) is declared directly in `values.yaml` rather than generated inside the template, following the pattern used by [argo-cd's Helm chart](https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/values.yaml). This makes the default behavior transparent and overridable.
- `backendRefs` are auto-injected per rule only when the user does not specify them, so the template is zero-config by default but fully customizable.
- Mutual exclusivity with Ingress is enforced at render time via `fail` — users get a clear error message instead of silently creating both resources.

**No breaking changes** — all new values default to `disabled`/empty, so existing deployments are unaffected.

**Validated scenarios:**

| Scenario | Result |
|---|---|
| Default rule (auto `backendRefs`, port 8080) | ✅ |
| TLS enabled (auto-selects port 8443) | ✅ |
| Custom `backendRefs` override | ✅ |
| Ingress + HTTPRoute both enabled | ✅ Fails with clear message |
| HTTPRoute enabled without `parentRefs` | ✅ Fails with clear message |
| CI values file (`with-httproute-values.yaml`) | ✅ |
| `connect.create: false` suppresses HTTPRoute | ✅ |